### PR TITLE
Add highlight sound, live config application, desktop-audio detection, and UI preview/dragging improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ fps             = 60
 encoder         = "auto"   # auto | h264_nvenc | libx264 | hevc_nvenc | h264_vaapi
 backend         = "auto"   # auto | gsr | wf-recorder | ffmpeg
 capture_audio   = true
+apply_watermark = false   # enable only if you want watermark text on exports
 
 [hotkeys]
 clip = "KEY_F9"

--- a/vice/audio.py
+++ b/vice/audio.py
@@ -6,6 +6,7 @@ Three sounds are pre-generated at import time:
   CLIP_SOUND     — quick two-note ascending ping (clip saved)
   SESSION_START  — three ascending tones (session recording started)
   SESSION_END    — three descending tones (session recording stopped)
+  HIGHLIGHT_SOUND — soft single chime (session highlight marked)
 
 All playback is non-blocking (asyncio task).
 No external audio files needed — pure Python + stdlib wave module.
@@ -85,6 +86,7 @@ def _make_wav(*tones: tuple[float, float], gap: float = 0.012) -> bytes:
 CLIP_SOUND    = _make_wav((880, 0.07), (1109, 0.11))
 SESSION_START = _make_wav((523, 0.09), (659, 0.09), (784, 0.13))
 SESSION_END   = _make_wav((784, 0.09), (659, 0.09), (523, 0.14))
+HIGHLIGHT_SOUND = _make_wav((988, 0.06))
 
 
 # ── Playback ───────────────────────────────────────────────────────────────────
@@ -94,12 +96,14 @@ _TMP_DIR   = Path("/tmp/vice")
 _TMP_CLIP  = _TMP_DIR / "snd_clip.wav"
 _TMP_START = _TMP_DIR / "snd_session_start.wav"
 _TMP_END   = _TMP_DIR / "snd_session_end.wav"
+_TMP_HL    = _TMP_DIR / "snd_highlight.wav"
 
 # Map sound bytes → stable temp path (written once, reused)
 _SOUND_MAP: dict[int, Path] = {
     id(CLIP_SOUND):    _TMP_CLIP,
     id(SESSION_START): _TMP_START,
     id(SESSION_END):   _TMP_END,
+    id(HIGHLIGHT_SOUND): _TMP_HL,
 }
 
 
@@ -166,3 +170,8 @@ def play_session_start() -> None:
 def play_session_end() -> None:
     """Fire-and-forget: play the session-ended notification sound."""
     asyncio.create_task(_play(SESSION_END))
+
+
+def play_highlight() -> None:
+    """Fire-and-forget: play the session-highlight marker sound."""
+    asyncio.create_task(_play(HIGHLIGHT_SOUND))

--- a/vice/config.py
+++ b/vice/config.py
@@ -38,6 +38,9 @@ class RecordingConfig:
     backend: str = "auto"
     # Include desktop audio in clips.
     capture_audio: bool = True
+    # Burn the "Clipped with Vice" watermark into exported clips.
+    # Disabled by default to avoid encoding spikes while gaming.
+    apply_watermark: bool = False
     # PulseAudio/PipeWire sink name. "default" works for most setups.
     audio_sink: str = "default"
 

--- a/vice/hotkey.py
+++ b/vice/hotkey.py
@@ -67,6 +67,14 @@ class HotkeyListener:
         """
         self._double_bindings.setdefault(key_name, []).append(callback)
 
+    def clear_bindings(self) -> None:
+        """Remove all hotkey bindings and cancel pending single-tap timers."""
+        self._bindings.clear()
+        self._double_bindings.clear()
+        for t in self._pending.values():
+            t.cancel()
+        self._pending.clear()
+
     async def start(self) -> None:
         """Discover keyboards and spawn a listener task per device."""
         keyboards = _find_keyboards()

--- a/vice/main.py
+++ b/vice/main.py
@@ -67,6 +67,7 @@ class ViceDaemon:
             self.share = ShareServer(self.cfg)
             self.share.trigger_clip_cb = self._handle_clip_hotkey
             self.share.get_status_cb   = self._get_status
+            self.share.apply_config_cb = self._apply_live_config
             await self.share.start()
 
         # Recorder callback — fires for both normal clips and session clips
@@ -84,18 +85,15 @@ class ViceDaemon:
                         "type": "status", "recording": True,
                         "backend": self.recorder.name,
                         "session_active": self._session_active,
+                        "clip_key": self.cfg.hotkeys.clip,
                     })
                 )
 
         self.recorder.on_clip_saved(_on_clip_saved)
 
         # Hotkeys
+        self._bind_hotkeys()
         clip_key = self.cfg.hotkeys.clip
-        if clip_key:
-            # Single tap → save clip (or add session highlight)
-            self.hotkeys.on(clip_key, self._handle_clip_hotkey)
-            # Double tap → toggle session recording
-            self.hotkeys.on_double(clip_key, self._handle_session_toggle)
 
         PID_FILE.write_text(str(os.getpid()))
 
@@ -130,12 +128,35 @@ class ViceDaemon:
         await stop_event.wait()
         await self._shutdown(server)
 
+    def _bind_hotkeys(self) -> None:
+        """(Re)bind runtime hotkeys from current config."""
+        self.hotkeys.clear_bindings()
+        clip_key = self.cfg.hotkeys.clip
+        if clip_key:
+            # Single tap → save clip (or add session highlight)
+            self.hotkeys.on(clip_key, self._handle_clip_hotkey)
+            # Double tap → toggle session recording
+            self.hotkeys.on_double(clip_key, self._handle_session_toggle)
+
+    async def _apply_live_config(self) -> None:
+        """Apply config changes that can be updated without daemon restart."""
+        self._bind_hotkeys()
+        if self.share:
+            await self.share.broadcast({
+                "type": "status",
+                "recording": True,
+                "backend": self.recorder.name,
+                "session_active": self._session_active,
+                "clip_key": self.cfg.hotkeys.clip,
+            })
+
     def _get_status(self) -> dict:
         return {
             "recording":      True,
             "backend":        self.recorder.name,
             "clips":          self._clip_count,
             "session_active": self._session_active,
+            "clip_key": self.cfg.hotkeys.clip,
         }
 
     async def _shutdown(self, server) -> None:
@@ -161,6 +182,7 @@ class ViceDaemon:
             entry   = {"time": round(elapsed, 3), "label": label, "color": color}
             self._session_highlights.append(entry)
             click.echo(f"[Vice] Session highlight at {elapsed:.1f}s", err=True)
+            audio.play_highlight()
             if self.share:
                 asyncio.create_task(
                     self.share.broadcast({
@@ -257,6 +279,7 @@ class ViceDaemon:
                     "output":         self.cfg.output.directory,
                     "share_url":      self.share.base_url() if self.share else None,
                     "session_active": self._session_active,
+                    "clip_key":       self.cfg.hotkeys.clip,
                 }).encode() + b"\n")
             elif cmd == "url":
                 url = self.share.base_url() if self.share else ""

--- a/vice/recorder.py
+++ b/vice/recorder.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 import shutil
 import signal
 import subprocess
@@ -61,6 +62,43 @@ def _run_ok(cmd: list[str]) -> bool:
 
 def _has(tool: str) -> bool:
     return shutil.which(tool) is not None
+
+
+def _desktop_audio_source(preferred: str) -> str:
+    """
+    Resolve a Pulse/PipeWire source name that captures desktop output audio.
+
+    When users leave audio_sink as "default", ffmpeg/wf-recorder may record
+    the current default *input* source (microphone) on some setups. We prefer
+    the default sink's monitor source so clips contain system/game audio.
+    """
+    if preferred and preferred != "default":
+        return preferred
+
+    if not _has("pactl"):
+        return preferred
+
+    try:
+        sink = subprocess.check_output(
+            ["pactl", "get-default-sink"], text=True, stderr=subprocess.DEVNULL
+        ).strip()
+        if sink:
+            return f"{sink}.monitor"
+    except Exception:
+        pass
+
+    try:
+        out = subprocess.check_output(
+            ["pactl", "list", "short", "sources"], text=True, stderr=subprocess.DEVNULL
+        )
+        for line in out.splitlines():
+            cols = re.split(r"\s+", line.strip())
+            if len(cols) > 1 and cols[1].endswith(".monitor"):
+                return cols[1]
+    except Exception:
+        pass
+
+    return preferred
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -229,7 +267,8 @@ class Recorder(ABC):
             log.error("Session file not found after stop: %s", path)
             return None
 
-        await _apply_watermark(path)
+        if self.cfg.recording.apply_watermark:
+            await _apply_watermark(path)
         log.info("Session clip saved: %s", path)
         self._emit(path)
         return path
@@ -240,11 +279,15 @@ class Recorder(ABC):
         encoder = choose_encoder(rc.encoder)
 
         if _is_wayland():
-            # wf-recorder is the most reliable direct-to-file tool on Wayland
+            # Prefer gpu-screen-recorder on Wayland (especially smoother on NVIDIA).
+            if _has("gpu-screen-recorder"):
+                return self._gsr_session_cmd(out_path, rc)
+
+            # Fallback: wf-recorder direct-to-file on Wayland.
             if _has("wf-recorder"):
                 cmd = ["wf-recorder", "--force-yuv", "-f", str(out_path)]
                 if rc.capture_audio:
-                    cmd += ["--audio"]
+                    cmd += [f"--audio={_desktop_audio_source(rc.audio_sink)}"]
                 if encoder in ("h264_nvenc", "hevc_nvenc"):
                     cmd += ["-c", encoder]
                 elif encoder == "h264_vaapi":
@@ -252,8 +295,8 @@ class Recorder(ABC):
                 else:
                     cmd += ["-c", "libx264"]
                 return cmd
-            # Fall through to ffmpeg (Wayland capture via pipewire portal or kmsgrab)
-            # For simplicity, use x11grab if DISPLAY is also set (XWayland)
+
+            # Last resort on XWayland sessions.
             if os.environ.get("DISPLAY") and _has("ffmpeg"):
                 return self._ffmpeg_session_cmd(out_path, encoder, rc)
             return None
@@ -262,6 +305,17 @@ class Recorder(ABC):
             return self._ffmpeg_session_cmd(out_path, encoder, rc)
 
         return None
+
+    @staticmethod
+    def _gsr_session_cmd(out_path: Path, rc) -> list[str]:
+        cmd = ["gpu-screen-recorder"]
+        cmd += ["-w", "screen" if _is_wayland() else os.environ.get("DISPLAY", ":0")]
+        cmd += ["-f", str(rc.fps)]
+        cmd += ["-c", "mp4"]
+        if rc.capture_audio:
+            cmd += ["-a", "default_output"]
+        cmd += ["-o", str(out_path)]
+        return cmd
 
     @staticmethod
     def _ffmpeg_session_cmd(out_path: Path, encoder: str, rc) -> list[str]:
@@ -284,7 +338,7 @@ class Recorder(ABC):
             cmd += ["-s", res]
         cmd += ["-i", display]
         if rc.capture_audio:
-            cmd += ["-f", "pulse", "-i", rc.audio_sink]
+            cmd += ["-f", "pulse", "-i", _desktop_audio_source(rc.audio_sink)]
         cmd += _encoder_flags(encoder, rc.crf)
         if rc.capture_audio:
             cmd += ["-c:a", "aac", "-b:a", "128k"]
@@ -296,14 +350,11 @@ class Recorder(ABC):
 # Clip trimming helper (used by GSR backend)
 # ──────────────────────────────────────────────────────────────────────────────
 
-import re as _re
-
-
 def _next_clip_path(out_dir: Path) -> Path:
     """Return the next available Vice_Clip_N.mp4 path in out_dir."""
     max_n = 0
     for f in out_dir.glob("Vice_Clip_*.mp4"):
-        m = _re.match(r"^Vice_Clip_(\d+)\.mp4$", f.name)
+        m = re.match(r"^Vice_Clip_(\d+)\.mp4$", f.name)
         if m:
             n = int(m.group(1))
             if n > max_n:
@@ -315,7 +366,7 @@ def _next_session_path(out_dir: Path) -> Path:
     """Return the next available Vice_Session_N.mp4 path in out_dir."""
     max_n = 0
     for f in out_dir.glob("Vice_Session_*.mp4"):
-        m = _re.match(r"^Vice_Session_(\d+)\.mp4$", f.name)
+        m = re.match(r"^Vice_Session_(\d+)\.mp4$", f.name)
         if m:
             n = int(m.group(1))
             if n > max_n:
@@ -528,7 +579,8 @@ class GSRRecorder(Recorder):
                 self._seen_files = {f.name for f in self._out_dir.glob("*.mp4")}
                 # GSR saves the entire buffer; trim to the requested clip duration.
                 trimmed = await _trim_to_last_n_seconds(newest, self.cfg.recording.clip_duration)
-                await _apply_watermark(trimmed)
+                if self.cfg.recording.apply_watermark:
+                    await _apply_watermark(trimmed)
                 log.info("Clip saved: %s", trimmed)
                 self._emit(trimmed)
                 return trimmed
@@ -577,7 +629,7 @@ class SegmentRecorder(Recorder):
             # wf-recorder geometry flag
             pass  # resolution is auto by default; geometry can be set with -g
         if rc.capture_audio:
-            cmd += ["--audio"]
+            cmd += [f"--audio={_desktop_audio_source(rc.audio_sink)}"]
         # Use ffmpeg codec flags via wf-recorder's -c option
         codec = self._encoder
         if codec in ("h264_nvenc", "hevc_nvenc"):
@@ -600,7 +652,7 @@ class SegmentRecorder(Recorder):
         cmd += ["-i", display]
 
         if rc.capture_audio:
-            cmd += ["-f", "pulse", "-i", rc.audio_sink]
+            cmd += ["-f", "pulse", "-i", _desktop_audio_source(rc.audio_sink)]
 
         enc_flags = _encoder_flags(self._encoder, rc.crf)
         cmd += enc_flags
@@ -774,7 +826,8 @@ class SegmentRecorder(Recorder):
             log.error("ffmpeg timed out during clip extraction")
             return None
 
-        await _apply_watermark(out_path)
+        if self.cfg.recording.apply_watermark:
+            await _apply_watermark(out_path)
         log.info("Clip saved: %s", out_path)
         self._emit(out_path)
         return out_path

--- a/vice/share.py
+++ b/vice/share.py
@@ -99,10 +99,15 @@ async def _make_thumb(path: Path) -> Path:
     if thumb.exists():
         return thumb
     try:
+        # Seek a little after the start so we avoid intro black frames.
+        # Keep -ss after -i for accurate frame selection.
         proc = await asyncio.create_subprocess_exec(
             "ffmpeg", "-hide_banner", "-loglevel", "error",
-            "-ss", "2", "-i", str(path),
-            "-vframes", "1", "-vf", "scale=640:-2", "-q:v", "4",
+            "-i", str(path),
+            "-ss", "0.75",
+            "-frames:v", "1",
+            "-vf", "thumbnail,scale=640:-2",
+            "-q:v", "4",
             str(thumb),
             stdout=asyncio.subprocess.DEVNULL,
             stderr=asyncio.subprocess.DEVNULL,
@@ -168,6 +173,8 @@ class ShareServer:
         self.trigger_clip_cb: Optional[Callable[[], Coroutine]] = None
         # Injected so /api/status can report live state
         self.get_status_cb: Optional[Callable[[], dict]] = None
+        # Injected so config changes can be applied without restart when possible.
+        self.apply_config_cb: Optional[Callable[[], Coroutine]] = None
 
         self._setup_routes()
 
@@ -279,7 +286,7 @@ class ShareServer:
         return self._meta[slug]
 
     def _clip_json(self, slug: str, path: Path, meta: dict) -> dict:
-        base = self._tunnel_url or self._base_url
+        public_base = self._tunnel_url or self._base_url
         try:
             st = path.stat()
             size = st.st_size
@@ -294,9 +301,11 @@ class ShareServer:
             "duration":   meta.get("duration", 0),
             "width":      meta.get("width",    0),
             "height":     meta.get("height",   0),
-            "share_url":  f"{base}/c/{slug}",
-            "video_url":  f"{base}/v/{slug}",
-            "thumb_url":  f"{base}/t/{slug}",
+            # Keep share links public, but serve media via local relative URLs
+            # so the app UI never fetches video through an external tunnel.
+            "share_url":  f"{public_base}/c/{slug}",
+            "video_url":  f"/v/{slug}",
+            "thumb_url":  f"/t/{slug}",
         }
 
     # ── route handlers ────────────────────────────────────────────────────────
@@ -432,6 +441,8 @@ class ShareServer:
 
         # Sanitise — no path separators; always .mp4
         new_name = new_name.replace("/", "").replace("\\", "").replace("\0", "")
+        if " " in new_name:
+            return web.json_response({"ok": False, "error": "Clip name cannot contain spaces"})
         if not new_name.lower().endswith(".mp4"):
             new_name += ".mp4"
 
@@ -501,6 +512,12 @@ class ShareServer:
                     h["label"] = (body["label"] or "Highlight").strip() or "Highlight"
                 if "color" in body:
                     h["color"] = body["color"]
+                if "time" in body:
+                    try:
+                        h["time"] = round(max(0.0, float(body["time"])), 3)
+                    except (TypeError, ValueError):
+                        pass
+                hl.sort(key=lambda x: float(x.get("time", 0)))
                 _save_highlights(slug, hl)
                 return web.json_response({"ok": True})
         return web.json_response({"ok": False, "error": "highlight not found"})
@@ -586,9 +603,16 @@ class ShareServer:
             }),
         )
         save_cfg(new_cfg)
-        # Apply live (takes effect on next daemon restart for recording settings)
+        # Apply live (some settings still require daemon restart, e.g. recorder backend).
         for field in ("recording", "hotkeys", "output", "sharing"):
             setattr(self.cfg, field, getattr(new_cfg, field))
+
+        if self.apply_config_cb:
+            try:
+                await self.apply_config_cb()
+            except Exception as exc:
+                log.warning("Live config apply failed: %s", exc)
+
         return web.json_response({"ok": True})
 
     async def _api_status(self, _: web.Request) -> web.Response:

--- a/vice/ui/index.html
+++ b/vice/ui/index.html
@@ -802,6 +802,7 @@
       transition: transform .12s;
     }
     .hl-marker:hover { transform: translate(-50%,-50%) scale(1.45); }
+    .hl-marker.dragging { transform: translate(-50%,-50%) scale(1.35); box-shadow: 0 0 0 2px rgba(255,255,255,.15); }
 
     /* Highlight list */
     .viewer-hl-list { display: flex; flex-direction: column; gap: 3px; max-height: 136px; overflow-y: auto; }
@@ -1263,7 +1264,7 @@
     </div>
 
     <div class="viewer-video-wrap">
-      <video id="viewer-video" controls></video>
+      <video id="viewer-video" preload="auto" playsinline controls></video>
       <button class="viewer-arrow viewer-arrow-prev" id="viewer-prev" onclick="viewerPrev()" title="Previous clip (←)">
         <svg data-lucide="chevron-left"></svg>
       </button>
@@ -1598,6 +1599,44 @@ async function fetchClips() {
   }
 }
 
+
+let activePreviewVideo = null;
+
+function stopActivePreview(resetTime = true) {
+  if (!activePreviewVideo) return;
+  try {
+    activePreviewVideo.pause();
+    if (resetTime) activePreviewVideo.currentTime = 0;
+  } catch (_) {}
+  activePreviewVideo = null;
+}
+
+function startPreview(slug) {
+  const card = document.getElementById('card-' + slug);
+  if (!card) return;
+  const vid = card.querySelector('video.preview-video');
+  if (!vid) return;
+
+  if (activePreviewVideo && activePreviewVideo !== vid) {
+    stopActivePreview(true);
+  }
+
+  activePreviewVideo = vid;
+  const maybe = vid.play();
+  if (maybe && typeof maybe.catch === 'function') maybe.catch(() => {});
+}
+
+function stopPreview(slug) {
+  const card = document.getElementById('card-' + slug);
+  const vid = card?.querySelector('video.preview-video');
+  if (!vid) return;
+  try {
+    vid.pause();
+    vid.currentTime = 0;
+  } catch (_) {}
+  if (activePreviewVideo === vid) activePreviewVideo = null;
+}
+
 function renderClips() {
   const grid  = document.getElementById('clips-grid');
   const empty = document.getElementById('clips-empty');
@@ -1607,6 +1646,7 @@ function renderClips() {
   sub.textContent = n === 0 ? 'No clips saved yet' : `${n} clip${n !== 1 ? 's' : ''}`;
   empty.style.display = n === 0 ? 'block' : 'none';
 
+  stopActivePreview(true);
   grid.innerHTML = clips.map(c => cardHTML(c)).join('');
   lucide.createIcons();
 }
@@ -1622,11 +1662,10 @@ function cardHTML(c) {
 
   return `
   <div class="clip-card" id="card-${escAttr(c.slug)}">
-    <div class="thumb-wrap" onclick="openViewer('${escAttr(c.slug)}')" style="cursor:pointer">
+    <div class="thumb-wrap" onclick="openViewer('${escAttr(c.slug)}')" onmouseenter="startPreview('${escAttr(c.slug)}')" onmouseleave="stopPreview('${escAttr(c.slug)}')" style="cursor:pointer">
       ${c.thumb_url
         ? `<img src="${c.thumb_url}" loading="lazy" alt="">
-           <video src="${c.video_url}" muted loop preload="none"
-                  onmouseenter="this.play()" onmouseleave="this.pause();this.currentTime=0"></video>`
+           <video class="preview-video" src="${c.video_url}" muted loop playsinline preload="none"></video>`
         : `<div class="thumb-placeholder"><svg data-lucide="film" width="24" height="24"></svg></div>`}
       ${durStr ? `<span class="clip-dur-badge">${durStr}</span>` : ''}
       ${isNew  ? `<span class="clip-new-badge">NEW</span>`       : ''}
@@ -1981,8 +2020,22 @@ function escAttr(s) { return String(s).replace(/&/g,'&amp;').replace(/'/g,'&#39;
 let viewerSlug       = null;
 let viewerIdx        = -1;
 let viewerHighlights = [];
+let draggingHighlight = null;
+
+function seekViewerTo(seconds) {
+  const vid = document.getElementById('viewer-video');
+  if (!vid) return;
+  const target = Math.max(0, Number(seconds) || 0);
+  try {
+    if (typeof vid.fastSeek === 'function') vid.fastSeek(target);
+    else vid.currentTime = target;
+  } catch (_) {
+    vid.currentTime = target;
+  }
+}
 
 function openViewer(slug) {
+  stopActivePreview(true);
   const idx = clips.findIndex(c => c.slug === slug);
   if (idx < 0) return;
   viewerSlug = slug;
@@ -2002,7 +2055,11 @@ function openViewer(slug) {
     clips.length > 1 ? `${idx + 1} / ${clips.length}` : '';
 
   const vid = document.getElementById('viewer-video');
-  vid.src = c.video_url;
+  if (vid.src !== c.video_url) {
+    vid.pause();
+    vid.src = c.video_url;
+    vid.load();
+  }
   document.getElementById('viewer-progress').style.width = '0%';
   document.getElementById('viewer-playhead').style.left  = '0%';
   document.getElementById('viewer-prev').disabled = idx === 0;
@@ -2014,6 +2071,7 @@ function openViewer(slug) {
 }
 
 function closeViewer() {
+  stopActivePreview(true);
   document.getElementById('viewer-modal').classList.remove('open');
   const vid = document.getElementById('viewer-video');
   vid.pause(); vid.src = '';
@@ -2031,7 +2089,7 @@ function viewerTimelineClick(e) {
   const vid = document.getElementById('viewer-video');
   if (!vid.duration) return;
   const rect = document.getElementById('viewer-timeline').getBoundingClientRect();
-  vid.currentTime = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width)) * vid.duration;
+  seekViewerTo(Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width)) * vid.duration);
 }
 
 (function() {
@@ -2092,8 +2150,9 @@ function renderViewerHighlights() {
     m.className  = 'hl-marker';
     m.style.left = pct + '%';
     m.style.background = color;
-    m.title      = `${hl.label} — ${fmtSec(hl.time, true)}`;
-    m.onclick    = ev => { ev.stopPropagation(); vid.currentTime = hl.time; };
+    m.title      = `${hl.label} — ${fmtSec(hl.time, true)} (drag to move)`;
+    m.onpointerdown = ev => beginHighlightDrag(ev, hl, m);
+    m.onclick    = ev => { if (!draggingHighlight) { ev.stopPropagation(); seekViewerTo(hl.time); } };
     markersEl.appendChild(m);
   });
 
@@ -2124,7 +2183,7 @@ function renderViewerHighlights() {
     const timeEl = document.createElement('span');
     timeEl.className   = 'hl-time';
     timeEl.textContent = fmtSec(hl.time, true);
-    timeEl.onclick     = ev => { ev.stopPropagation(); vid.currentTime = hl.time; };
+    timeEl.onclick     = ev => { ev.stopPropagation(); seekViewerTo(hl.time); };
 
     const labelWrap = document.createElement('span');
     labelWrap.className = 'hl-label-wrap';
@@ -2144,10 +2203,80 @@ function renderViewerHighlights() {
     item.appendChild(timeEl);
     item.appendChild(labelWrap);
     item.appendChild(delBtn);
-    item.onclick = () => { vid.currentTime = hl.time; };
+    item.onclick = () => { seekViewerTo(hl.time); };
     listEl.appendChild(item);
   });
   lucide.createIcons();
+}
+
+function dragTimeFromPointer(ev) {
+  const vid = document.getElementById('viewer-video');
+  const tl  = document.getElementById('viewer-timeline');
+  if (!vid || !tl || !vid.duration) return null;
+  const rect = tl.getBoundingClientRect();
+  const x = Math.max(rect.left, Math.min(rect.right, ev.clientX));
+  const ratio = Math.max(0, Math.min(1, (x - rect.left) / rect.width));
+  return ratio * vid.duration;
+}
+
+function beginHighlightDrag(ev, hl, markerEl) {
+  if (ev.button !== undefined && ev.button !== 0) return;
+  ev.preventDefault();
+  ev.stopPropagation();
+  const t = dragTimeFromPointer(ev);
+  draggingHighlight = { id: hl.id, markerEl, startTime: hl.time, time: t ?? hl.time };
+  markerEl.classList.add('dragging');
+
+  const onMove = moveEv => {
+    if (!draggingHighlight) return;
+    const next = dragTimeFromPointer(moveEv);
+    if (next == null) return;
+    draggingHighlight.time = next;
+    const item = viewerHighlights.find(h => h.id === draggingHighlight.id);
+    if (item) {
+      item.time = Number(next.toFixed(3));
+      viewerHighlights.sort((a, b) => a.time - b.time);
+      renderViewerHighlights();
+    }
+  };
+
+  const onUp = async upEv => {
+    window.removeEventListener('pointermove', onMove, true);
+    window.removeEventListener('pointerup', onUp, true);
+    window.removeEventListener('pointercancel', onUp, true);
+
+    const cur = draggingHighlight;
+    draggingHighlight = null;
+    if (cur?.markerEl) cur.markerEl.classList.remove('dragging');
+
+    if (!cur) return;
+    const finalTime = dragTimeFromPointer(upEv);
+    const applied = Number((finalTime ?? cur.time).toFixed(3));
+    const item = viewerHighlights.find(h => h.id === cur.id);
+    if (item) item.time = applied;
+    viewerHighlights.sort((a, b) => a.time - b.time);
+    renderViewerHighlights();
+
+    if (!viewerSlug) return;
+    try {
+      await fetch(`/api/clips/${viewerSlug}/highlights/${cur.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ time: applied }),
+      });
+      toast(`Highlight moved to ${fmtSec(applied, true)}`, 'ok');
+    } catch (_) {
+      const old = viewerHighlights.find(h => h.id === cur.id);
+      if (old) old.time = cur.startTime;
+      viewerHighlights.sort((a, b) => a.time - b.time);
+      renderViewerHighlights();
+      toast('Failed to move highlight', 'err');
+    }
+  };
+
+  window.addEventListener('pointermove', onMove, true);
+  window.addEventListener('pointerup', onUp, true);
+  window.addEventListener('pointercancel', onUp, true);
 }
 
 function showColorPicker(hlId, currentColor, anchorEl) {
@@ -2316,6 +2445,13 @@ function startRename(slug) {
     const newName = input.value.trim();
     if (!newName || newName === current) {
       input.replaceWith(nameEl);
+      return;
+    }
+    if (newName.includes(' ')) {
+      toast('Clip name cannot contain spaces', 'err');
+      submitted = false;
+      input.focus();
+      input.select();
       return;
     }
     try {


### PR DESCRIPTION
### Motivation

- Add a soft audio cue for session highlights and make some settings updatable at runtime via the share server UI. 
- Ensure desktop/system audio is captured reliably across Pulse/PipeWire setups and avoid always applying expensive watermarks by making it configurable. 
- Improve the web UI with hover previews, draggable highlights, more accurate thumbnail extraction, and stricter rename validation.

### Description

- Audio: added `HIGHLIGHT_SOUND` and `play_highlight()` in `vice/audio.py` and play it when marking a session highlight. 
- Config: added `apply_watermark: bool` to `RecordingConfig` and README; watermarking is now conditional on this flag in session/clip save paths in `vice/recorder.py`. 
- Recorder: implemented `_desktop_audio_source()` to prefer sink monitor sources and wired it into wf-recorder/ffmpeg commands and segment/ffmpeg session builds; added a small `gpu-screen-recorder` session command helper and used `_desktop_audio_source` for audio capture; fixed regex usage and unified imports. 
- Hotkeys/Daemon: added `HotkeyListener.clear_bindings()` and a `_bind_hotkeys()` + `_apply_live_config()` flow in `vice/main.py` so hotkey and some status changes can be applied without restarting the daemon; share server now receives `apply_config_cb`. 
- Share server: added `apply_config_cb` wiring, run live config application after `/api/config` save, changed clip JSON to serve media via relative local URLs while keeping public share links external, forbids rename strings containing spaces, and allow PATCH to update highlight times (with sorting). 
- Thumbnails: changed ffmpeg thumbnail extraction to seek after `-i` and pick a thumbnail frame with `thumbnail,scale=640:-2` to avoid black intro frames. 
- UI: many frontend improvements in `vice/ui/index.html`: preview video autoplay on hover with single active preview, `preload`/`playsinline` on viewer video, stop previews when opening viewer, seek helper using `fastSeek` where available, draggable highlight markers (pointer-based drag to update time and PATCH to server), UI polish (dragging CSS class), and several robustness fixes in viewer playback and highlight handling.

### Testing

- No automated test suite was present to run as part of this change, so no automated tests were executed.

