### PR TITLE
Highlights, live-config, desktop-audio detection, thumbnail/versioning, UI/UX & watermark opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ fps             = 60
 encoder         = "auto"   # auto | h264_nvenc | libx264 | hevc_nvenc | h264_vaapi
 backend         = "auto"   # auto | gsr | wf-recorder | ffmpeg
 capture_audio   = true
+apply_watermark = false   # enable only if you want watermark text on exports
 
 [hotkeys]
 clip = "KEY_F9"

--- a/vice/audio.py
+++ b/vice/audio.py
@@ -6,6 +6,7 @@ Three sounds are pre-generated at import time:
   CLIP_SOUND     — quick two-note ascending ping (clip saved)
   SESSION_START  — three ascending tones (session recording started)
   SESSION_END    — three descending tones (session recording stopped)
+  HIGHLIGHT_SOUND — soft single chime (session highlight marked)
 
 All playback is non-blocking (asyncio task).
 No external audio files needed — pure Python + stdlib wave module.
@@ -85,6 +86,7 @@ def _make_wav(*tones: tuple[float, float], gap: float = 0.012) -> bytes:
 CLIP_SOUND    = _make_wav((880, 0.07), (1109, 0.11))
 SESSION_START = _make_wav((523, 0.09), (659, 0.09), (784, 0.13))
 SESSION_END   = _make_wav((784, 0.09), (659, 0.09), (523, 0.14))
+HIGHLIGHT_SOUND = _make_wav((988, 0.06))
 
 
 # ── Playback ───────────────────────────────────────────────────────────────────
@@ -94,12 +96,14 @@ _TMP_DIR   = Path("/tmp/vice")
 _TMP_CLIP  = _TMP_DIR / "snd_clip.wav"
 _TMP_START = _TMP_DIR / "snd_session_start.wav"
 _TMP_END   = _TMP_DIR / "snd_session_end.wav"
+_TMP_HL    = _TMP_DIR / "snd_highlight.wav"
 
 # Map sound bytes → stable temp path (written once, reused)
 _SOUND_MAP: dict[int, Path] = {
     id(CLIP_SOUND):    _TMP_CLIP,
     id(SESSION_START): _TMP_START,
     id(SESSION_END):   _TMP_END,
+    id(HIGHLIGHT_SOUND): _TMP_HL,
 }
 
 
@@ -166,3 +170,8 @@ def play_session_start() -> None:
 def play_session_end() -> None:
     """Fire-and-forget: play the session-ended notification sound."""
     asyncio.create_task(_play(SESSION_END))
+
+
+def play_highlight() -> None:
+    """Fire-and-forget: play the session-highlight marker sound."""
+    asyncio.create_task(_play(HIGHLIGHT_SOUND))

--- a/vice/config.py
+++ b/vice/config.py
@@ -38,6 +38,9 @@ class RecordingConfig:
     backend: str = "auto"
     # Include desktop audio in clips.
     capture_audio: bool = True
+    # Burn the "Clipped with Vice" watermark into exported clips.
+    # Disabled by default to avoid encoding spikes while gaming.
+    apply_watermark: bool = False
     # PulseAudio/PipeWire sink name. "default" works for most setups.
     audio_sink: str = "default"
 

--- a/vice/hotkey.py
+++ b/vice/hotkey.py
@@ -67,6 +67,14 @@ class HotkeyListener:
         """
         self._double_bindings.setdefault(key_name, []).append(callback)
 
+    def clear_bindings(self) -> None:
+        """Remove all hotkey bindings and cancel pending single-tap timers."""
+        self._bindings.clear()
+        self._double_bindings.clear()
+        for t in self._pending.values():
+            t.cancel()
+        self._pending.clear()
+
     async def start(self) -> None:
         """Discover keyboards and spawn a listener task per device."""
         keyboards = _find_keyboards()

--- a/vice/main.py
+++ b/vice/main.py
@@ -67,6 +67,7 @@ class ViceDaemon:
             self.share = ShareServer(self.cfg)
             self.share.trigger_clip_cb = self._handle_clip_hotkey
             self.share.get_status_cb   = self._get_status
+            self.share.apply_config_cb = self._apply_live_config
             await self.share.start()
 
         # Recorder callback — fires for both normal clips and session clips
@@ -84,18 +85,15 @@ class ViceDaemon:
                         "type": "status", "recording": True,
                         "backend": self.recorder.name,
                         "session_active": self._session_active,
+                        "clip_key": self.cfg.hotkeys.clip,
                     })
                 )
 
         self.recorder.on_clip_saved(_on_clip_saved)
 
         # Hotkeys
+        self._bind_hotkeys()
         clip_key = self.cfg.hotkeys.clip
-        if clip_key:
-            # Single tap → save clip (or add session highlight)
-            self.hotkeys.on(clip_key, self._handle_clip_hotkey)
-            # Double tap → toggle session recording
-            self.hotkeys.on_double(clip_key, self._handle_session_toggle)
 
         PID_FILE.write_text(str(os.getpid()))
 
@@ -130,12 +128,35 @@ class ViceDaemon:
         await stop_event.wait()
         await self._shutdown(server)
 
+    def _bind_hotkeys(self) -> None:
+        """(Re)bind runtime hotkeys from current config."""
+        self.hotkeys.clear_bindings()
+        clip_key = self.cfg.hotkeys.clip
+        if clip_key:
+            # Single tap → save clip (or add session highlight)
+            self.hotkeys.on(clip_key, self._handle_clip_hotkey)
+            # Double tap → toggle session recording
+            self.hotkeys.on_double(clip_key, self._handle_session_toggle)
+
+    async def _apply_live_config(self) -> None:
+        """Apply config changes that can be updated without daemon restart."""
+        self._bind_hotkeys()
+        if self.share:
+            await self.share.broadcast({
+                "type": "status",
+                "recording": True,
+                "backend": self.recorder.name,
+                "session_active": self._session_active,
+                "clip_key": self.cfg.hotkeys.clip,
+            })
+
     def _get_status(self) -> dict:
         return {
             "recording":      True,
             "backend":        self.recorder.name,
             "clips":          self._clip_count,
             "session_active": self._session_active,
+            "clip_key": self.cfg.hotkeys.clip,
         }
 
     async def _shutdown(self, server) -> None:
@@ -161,6 +182,7 @@ class ViceDaemon:
             entry   = {"time": round(elapsed, 3), "label": label, "color": color}
             self._session_highlights.append(entry)
             click.echo(f"[Vice] Session highlight at {elapsed:.1f}s", err=True)
+            audio.play_highlight()
             if self.share:
                 asyncio.create_task(
                     self.share.broadcast({
@@ -257,6 +279,7 @@ class ViceDaemon:
                     "output":         self.cfg.output.directory,
                     "share_url":      self.share.base_url() if self.share else None,
                     "session_active": self._session_active,
+                    "clip_key":       self.cfg.hotkeys.clip,
                 }).encode() + b"\n")
             elif cmd == "url":
                 url = self.share.base_url() if self.share else ""

--- a/vice/recorder.py
+++ b/vice/recorder.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 import shutil
 import signal
 import subprocess
@@ -61,6 +62,43 @@ def _run_ok(cmd: list[str]) -> bool:
 
 def _has(tool: str) -> bool:
     return shutil.which(tool) is not None
+
+
+def _desktop_audio_source(preferred: str) -> str:
+    """
+    Resolve a Pulse/PipeWire source name that captures desktop output audio.
+
+    When users leave audio_sink as "default", ffmpeg/wf-recorder may record
+    the current default *input* source (microphone) on some setups. We prefer
+    the default sink's monitor source so clips contain system/game audio.
+    """
+    if preferred and preferred != "default":
+        return preferred
+
+    if not _has("pactl"):
+        return preferred
+
+    try:
+        sink = subprocess.check_output(
+            ["pactl", "get-default-sink"], text=True, stderr=subprocess.DEVNULL
+        ).strip()
+        if sink:
+            return f"{sink}.monitor"
+    except Exception:
+        pass
+
+    try:
+        out = subprocess.check_output(
+            ["pactl", "list", "short", "sources"], text=True, stderr=subprocess.DEVNULL
+        )
+        for line in out.splitlines():
+            cols = re.split(r"\s+", line.strip())
+            if len(cols) > 1 and cols[1].endswith(".monitor"):
+                return cols[1]
+    except Exception:
+        pass
+
+    return preferred
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -229,7 +267,8 @@ class Recorder(ABC):
             log.error("Session file not found after stop: %s", path)
             return None
 
-        await _apply_watermark(path)
+        if self.cfg.recording.apply_watermark:
+            await _apply_watermark(path)
         log.info("Session clip saved: %s", path)
         self._emit(path)
         return path
@@ -240,11 +279,15 @@ class Recorder(ABC):
         encoder = choose_encoder(rc.encoder)
 
         if _is_wayland():
-            # wf-recorder is the most reliable direct-to-file tool on Wayland
+            # Prefer gpu-screen-recorder on Wayland (especially smoother on NVIDIA).
+            if _has("gpu-screen-recorder"):
+                return self._gsr_session_cmd(out_path, rc)
+
+            # Fallback: wf-recorder direct-to-file on Wayland.
             if _has("wf-recorder"):
                 cmd = ["wf-recorder", "--force-yuv", "-f", str(out_path)]
                 if rc.capture_audio:
-                    cmd += ["--audio"]
+                    cmd += [f"--audio={_desktop_audio_source(rc.audio_sink)}"]
                 if encoder in ("h264_nvenc", "hevc_nvenc"):
                     cmd += ["-c", encoder]
                 elif encoder == "h264_vaapi":
@@ -252,8 +295,8 @@ class Recorder(ABC):
                 else:
                     cmd += ["-c", "libx264"]
                 return cmd
-            # Fall through to ffmpeg (Wayland capture via pipewire portal or kmsgrab)
-            # For simplicity, use x11grab if DISPLAY is also set (XWayland)
+
+            # Last resort on XWayland sessions.
             if os.environ.get("DISPLAY") and _has("ffmpeg"):
                 return self._ffmpeg_session_cmd(out_path, encoder, rc)
             return None
@@ -262,6 +305,17 @@ class Recorder(ABC):
             return self._ffmpeg_session_cmd(out_path, encoder, rc)
 
         return None
+
+    @staticmethod
+    def _gsr_session_cmd(out_path: Path, rc) -> list[str]:
+        cmd = ["gpu-screen-recorder"]
+        cmd += ["-w", "screen" if _is_wayland() else os.environ.get("DISPLAY", ":0")]
+        cmd += ["-f", str(rc.fps)]
+        cmd += ["-c", "mp4"]
+        if rc.capture_audio:
+            cmd += ["-a", "default_output"]
+        cmd += ["-o", str(out_path)]
+        return cmd
 
     @staticmethod
     def _ffmpeg_session_cmd(out_path: Path, encoder: str, rc) -> list[str]:
@@ -284,7 +338,7 @@ class Recorder(ABC):
             cmd += ["-s", res]
         cmd += ["-i", display]
         if rc.capture_audio:
-            cmd += ["-f", "pulse", "-i", rc.audio_sink]
+            cmd += ["-f", "pulse", "-i", _desktop_audio_source(rc.audio_sink)]
         cmd += _encoder_flags(encoder, rc.crf)
         if rc.capture_audio:
             cmd += ["-c:a", "aac", "-b:a", "128k"]
@@ -296,14 +350,11 @@ class Recorder(ABC):
 # Clip trimming helper (used by GSR backend)
 # ──────────────────────────────────────────────────────────────────────────────
 
-import re as _re
-
-
 def _next_clip_path(out_dir: Path) -> Path:
     """Return the next available Vice_Clip_N.mp4 path in out_dir."""
     max_n = 0
     for f in out_dir.glob("Vice_Clip_*.mp4"):
-        m = _re.match(r"^Vice_Clip_(\d+)\.mp4$", f.name)
+        m = re.match(r"^Vice_Clip_(\d+)\.mp4$", f.name)
         if m:
             n = int(m.group(1))
             if n > max_n:
@@ -315,7 +366,7 @@ def _next_session_path(out_dir: Path) -> Path:
     """Return the next available Vice_Session_N.mp4 path in out_dir."""
     max_n = 0
     for f in out_dir.glob("Vice_Session_*.mp4"):
-        m = _re.match(r"^Vice_Session_(\d+)\.mp4$", f.name)
+        m = re.match(r"^Vice_Session_(\d+)\.mp4$", f.name)
         if m:
             n = int(m.group(1))
             if n > max_n:
@@ -528,7 +579,8 @@ class GSRRecorder(Recorder):
                 self._seen_files = {f.name for f in self._out_dir.glob("*.mp4")}
                 # GSR saves the entire buffer; trim to the requested clip duration.
                 trimmed = await _trim_to_last_n_seconds(newest, self.cfg.recording.clip_duration)
-                await _apply_watermark(trimmed)
+                if self.cfg.recording.apply_watermark:
+                    await _apply_watermark(trimmed)
                 log.info("Clip saved: %s", trimmed)
                 self._emit(trimmed)
                 return trimmed
@@ -577,7 +629,7 @@ class SegmentRecorder(Recorder):
             # wf-recorder geometry flag
             pass  # resolution is auto by default; geometry can be set with -g
         if rc.capture_audio:
-            cmd += ["--audio"]
+            cmd += [f"--audio={_desktop_audio_source(rc.audio_sink)}"]
         # Use ffmpeg codec flags via wf-recorder's -c option
         codec = self._encoder
         if codec in ("h264_nvenc", "hevc_nvenc"):
@@ -600,7 +652,7 @@ class SegmentRecorder(Recorder):
         cmd += ["-i", display]
 
         if rc.capture_audio:
-            cmd += ["-f", "pulse", "-i", rc.audio_sink]
+            cmd += ["-f", "pulse", "-i", _desktop_audio_source(rc.audio_sink)]
 
         enc_flags = _encoder_flags(self._encoder, rc.crf)
         cmd += enc_flags
@@ -774,7 +826,8 @@ class SegmentRecorder(Recorder):
             log.error("ffmpeg timed out during clip extraction")
             return None
 
-        await _apply_watermark(out_path)
+        if self.cfg.recording.apply_watermark:
+            await _apply_watermark(out_path)
         log.info("Clip saved: %s", out_path)
         self._emit(out_path)
         return out_path

--- a/vice/share.py
+++ b/vice/share.py
@@ -56,6 +56,23 @@ def _save_highlights(slug: str, highlights: list) -> None:
     (HIGHLIGHTS_DIR / f"{slug}.json").write_text(json.dumps(highlights))
 
 
+def _thumb_path(path: Path) -> Path:
+    """Return cache path unique to this clip file content/version."""
+    try:
+        st = path.stat()
+        key = f"{path.stem}_{st.st_size}_{st.st_mtime_ns}"
+    except OSError:
+        key = path.stem
+    return THUMB_DIR / f"{key}.jpg"
+
+
+def _purge_slug_thumbs(slug: str) -> None:
+    """Remove any cached thumbs for a slug (legacy + versioned variants)."""
+    THUMB_DIR.mkdir(parents=True, exist_ok=True)
+    for t in THUMB_DIR.glob(f"{slug}*.jpg"):
+        t.unlink(missing_ok=True)
+
+
 # ── helpers ──────────────────────────────────────────────────────────────────
 
 def _local_ip() -> str:
@@ -95,14 +112,19 @@ async def _ffprobe(path: Path) -> dict:
 async def _make_thumb(path: Path) -> Path:
     """Lazily generate a 640px-wide JPEG thumbnail stored in THUMB_DIR."""
     THUMB_DIR.mkdir(parents=True, exist_ok=True)
-    thumb = THUMB_DIR / f"{path.stem}.jpg"
+    thumb = _thumb_path(path)
     if thumb.exists():
         return thumb
     try:
+        # Seek a little after the start so we avoid intro black frames.
+        # Keep -ss after -i for accurate frame selection.
         proc = await asyncio.create_subprocess_exec(
             "ffmpeg", "-hide_banner", "-loglevel", "error",
-            "-ss", "2", "-i", str(path),
-            "-vframes", "1", "-vf", "scale=640:-2", "-q:v", "4",
+            "-i", str(path),
+            "-ss", "0.75",
+            "-frames:v", "1",
+            "-vf", "thumbnail,scale=640:-2",
+            "-q:v", "4",
             str(thumb),
             stdout=asyncio.subprocess.DEVNULL,
             stderr=asyncio.subprocess.DEVNULL,
@@ -168,6 +190,8 @@ class ShareServer:
         self.trigger_clip_cb: Optional[Callable[[], Coroutine]] = None
         # Injected so /api/status can report live state
         self.get_status_cb: Optional[Callable[[], dict]] = None
+        # Injected so config changes can be applied without restart when possible.
+        self.apply_config_cb: Optional[Callable[[], Coroutine]] = None
 
         self._setup_routes()
 
@@ -279,13 +303,16 @@ class ShareServer:
         return self._meta[slug]
 
     def _clip_json(self, slug: str, path: Path, meta: dict) -> dict:
-        base = self._tunnel_url or self._base_url
+        public_base = self._tunnel_url or self._base_url
         try:
             st = path.stat()
             size = st.st_size
+            mtime_ns = st.st_mtime_ns
             created_at = datetime.fromtimestamp(st.st_mtime).isoformat()
         except OSError:
-            size, created_at = 0, ""
+            size, mtime_ns, created_at = 0, 0, ""
+
+        thumb_rev = f"{size}-{mtime_ns}"
         return {
             "slug":       slug,
             "name":       path.name,
@@ -294,9 +321,12 @@ class ShareServer:
             "duration":   meta.get("duration", 0),
             "width":      meta.get("width",    0),
             "height":     meta.get("height",   0),
-            "share_url":  f"{base}/c/{slug}",
-            "video_url":  f"{base}/v/{slug}",
-            "thumb_url":  f"{base}/t/{slug}",
+            # Keep share links public, but serve media via local relative URLs
+            # so the app UI never fetches video through an external tunnel.
+            "share_url":  f"{public_base}/c/{slug}",
+            "video_url":  f"/v/{slug}",
+            # Cache-bust by clip file identity to avoid stale thumbs when slugs are reused.
+            "thumb_url":  f"/t/{slug}?v={thumb_rev}",
         }
 
     # ── route handlers ────────────────────────────────────────────────────────
@@ -372,7 +402,7 @@ class ShareServer:
         path = self._clips.pop(slug, None)
         if path and path.exists():
             path.unlink()
-        (THUMB_DIR      / f"{slug}.jpg" ).unlink(missing_ok=True)
+        _purge_slug_thumbs(slug)
         (HIGHLIGHTS_DIR / f"{slug}.json").unlink(missing_ok=True)
         self._meta.pop(slug, None)
         await self.broadcast({"type": "clip_deleted", "slug": slug})
@@ -414,7 +444,7 @@ class ShareServer:
 
         tmp.replace(path)
         # Clear cached thumbnail and metadata so they regenerate on next access
-        (THUMB_DIR / f"{slug}.jpg").unlink(missing_ok=True)
+        _purge_slug_thumbs(slug)
         self._meta.pop(slug, None)
         asyncio.create_task(self._broadcast_clip(slug, path))
         return web.json_response({"ok": True, "slug": slug})
@@ -432,6 +462,8 @@ class ShareServer:
 
         # Sanitise — no path separators; always .mp4
         new_name = new_name.replace("/", "").replace("\\", "").replace("\0", "")
+        if " " in new_name:
+            return web.json_response({"ok": False, "error": "Clip name cannot contain spaces"})
         if not new_name.lower().endswith(".mp4"):
             new_name += ".mp4"
 
@@ -445,7 +477,7 @@ class ShareServer:
         # Update internal state
         self._clips.pop(slug, None)
         self._clips[new_slug] = new_path
-        (THUMB_DIR / f"{slug}.jpg").unlink(missing_ok=True)
+        _purge_slug_thumbs(slug)
         self._meta.pop(slug, None)
 
         # Rename highlights file if it exists
@@ -501,6 +533,12 @@ class ShareServer:
                     h["label"] = (body["label"] or "Highlight").strip() or "Highlight"
                 if "color" in body:
                     h["color"] = body["color"]
+                if "time" in body:
+                    try:
+                        h["time"] = round(max(0.0, float(body["time"])), 3)
+                    except (TypeError, ValueError):
+                        pass
+                hl.sort(key=lambda x: float(x.get("time", 0)))
                 _save_highlights(slug, hl)
                 return web.json_response({"ok": True})
         return web.json_response({"ok": False, "error": "highlight not found"})
@@ -586,9 +624,16 @@ class ShareServer:
             }),
         )
         save_cfg(new_cfg)
-        # Apply live (takes effect on next daemon restart for recording settings)
+        # Apply live (some settings still require daemon restart, e.g. recorder backend).
         for field in ("recording", "hotkeys", "output", "sharing"):
             setattr(self.cfg, field, getattr(new_cfg, field))
+
+        if self.apply_config_cb:
+            try:
+                await self.apply_config_cb()
+            except Exception as exc:
+                log.warning("Live config apply failed: %s", exc)
+
         return web.json_response({"ok": True})
 
     async def _api_status(self, _: web.Request) -> web.Response:

--- a/vice/ui/index.html
+++ b/vice/ui/index.html
@@ -22,7 +22,8 @@
       --accent:       #3b82f6;
       --accent-hi:    #60a5fa;
       --accent-dim:   rgba(59,130,246,0.13);
-      --accent-glow:  0 0 28px rgba(59,130,246,0.20);
+      --accent-glow:  0 0 28px rgba(var(--accent-rgb),0.20);
+      --accent-rgb:   59,130,246;
       --text:         #e1e7f0;
       --muted:        #5a6b82;
       --muted-hi:     #8899b0;
@@ -161,14 +162,14 @@
     .tunnel-pill {
       display: none; align-items: center; gap: 5px;
       padding: 5px 9px; border-radius: 20px;
-      background: rgba(59,130,246,0.12);
-      border: 1px solid rgba(59,130,246,0.2);
+      background: rgba(var(--accent-rgb),0.12);
+      border: 1px solid rgba(var(--accent-rgb),0.2);
       font-size: 11px; font-weight: 500; color: var(--accent);
       cursor: pointer; transition: background .12s;
       overflow: hidden;
     }
     .tunnel-pill.visible { display: flex; }
-    .tunnel-pill:hover { background: rgba(59,130,246,0.2); }
+    .tunnel-pill:hover { background: rgba(var(--accent-rgb),0.2); }
     .tunnel-pill svg { width: 11px; height: 11px; flex-shrink: 0; }
     .tunnel-pill-text { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
@@ -199,11 +200,11 @@
     .btn svg { width: 13px; height: 13px; }
     .btn-primary {
       background: var(--accent); color: #fff;
-      box-shadow: 0 2px 10px rgba(59,130,246,0.3);
+      box-shadow: 0 2px 10px rgba(var(--accent-rgb),0.3);
     }
     .btn-primary:hover {
       background: var(--accent-hi);
-      box-shadow: 0 4px 14px rgba(59,130,246,0.4);
+      box-shadow: 0 4px 14px rgba(var(--accent-rgb),0.4);
     }
     .btn-ghost { background: rgba(255,255,255,0.06); color: var(--text); border: 1px solid var(--border); }
     .btn-ghost:hover { background: rgba(255,255,255,0.10); border-color: var(--border-hi); }
@@ -242,7 +243,7 @@
       transition: border-color .16s, transform .16s, box-shadow .16s;
     }
     .clip-card:hover {
-      border-color: rgba(59,130,246,.28);
+      border-color: rgba(var(--accent-rgb),.28);
       transform: translateY(-2px);
       box-shadow: 0 10px 30px rgba(0,0,0,.5), var(--accent-glow);
     }
@@ -301,7 +302,7 @@
       color: var(--text);
       font: inherit; font-size: 13px; font-weight: 600;
       padding: 2px 7px; outline: none;
-      box-shadow: 0 0 0 3px rgba(59,130,246,0.12);
+      box-shadow: 0 0 0 3px rgba(var(--accent-rgb),0.12);
     }
 
     /* ── Settings ───────────────────────────────────────────────────── */
@@ -344,7 +345,7 @@
     }
     select:focus, input:focus {
       border-color: var(--accent);
-      box-shadow: 0 0 0 3px rgba(59,130,246,0.12);
+      box-shadow: 0 0 0 3px rgba(var(--accent-rgb),0.12);
     }
     select {
       cursor: pointer; padding-right: 28px; appearance: none;
@@ -366,7 +367,7 @@
       -webkit-appearance: none;
       width: 14px; height: 14px; border-radius: 50%;
       background: var(--accent); cursor: pointer;
-      box-shadow: 0 0 8px rgba(59,130,246,.5);
+      box-shadow: 0 0 8px rgba(var(--accent-rgb),.5);
       transition: transform .1s;
     }
     input[type=range]::-webkit-slider-thumb:hover { transform: scale(1.2); }
@@ -664,7 +665,7 @@
     }
     .tl-selection {
       position: absolute; top: 0; bottom: 0;
-      background: rgba(59,130,246,.14);
+      background: rgba(var(--accent-rgb),.14);
       border-top: 2px solid var(--accent);
       border-bottom: 2px solid var(--accent);
       pointer-events: none;
@@ -676,7 +677,7 @@
       background: var(--accent);
       border-radius: 4px;
       cursor: ew-resize; z-index: 3;
-      box-shadow: 0 2px 12px rgba(59,130,246,.55);
+      box-shadow: 0 2px 12px rgba(var(--accent-rgb),.55);
       display: flex; align-items: center; justify-content: center;
       transition: transform .1s;
     }
@@ -788,7 +789,7 @@
       background: var(--accent); border: 2px solid #fff;
       border-radius: 50%; transform: translate(-50%, -50%);
       pointer-events: none; z-index: 3;
-      box-shadow: 0 0 8px rgba(59,130,246,.5);
+      box-shadow: 0 0 8px rgba(var(--accent-rgb),.5);
     }
     #viewer-hl-markers { position: absolute; inset: 0; pointer-events: none; overflow: visible; }
     .hl-marker {
@@ -802,6 +803,7 @@
       transition: transform .12s;
     }
     .hl-marker:hover { transform: translate(-50%,-50%) scale(1.45); }
+    .hl-marker.dragging { transform: translate(-50%,-50%) scale(1.35); box-shadow: 0 0 0 2px rgba(255,255,255,.15); }
 
     /* Highlight list */
     .viewer-hl-list { display: flex; flex-direction: column; gap: 3px; max-height: 136px; overflow-y: auto; }
@@ -869,6 +871,9 @@
       width: 3px; background: #f59e0b;
       transform: translateX(-50%); pointer-events: none;
       opacity: 0.8; z-index: 2;
+    }
+      @media (prefers-reduced-motion: reduce) {
+      * { animation: none !important; transition: none !important; }
     }
   </style>
 </head>
@@ -1263,7 +1268,7 @@
     </div>
 
     <div class="viewer-video-wrap">
-      <video id="viewer-video" controls></video>
+      <video id="viewer-video" preload="auto" playsinline controls></video>
       <button class="viewer-arrow viewer-arrow-prev" id="viewer-prev" onclick="viewerPrev()" title="Previous clip (←)">
         <svg data-lucide="chevron-left"></svg>
       </button>
@@ -1336,11 +1341,11 @@
 // Theme system
 // ═══════════════════════════════════════════════════════════════════
 const THEMES = {
-  blue:   { '--accent': '#3b82f6', '--accent-hi': '#60a5fa', '--accent-dim': 'rgba(59,130,246,0.13)',  '--accent-glow': '0 0 28px rgba(59,130,246,0.20)'  },
-  purple: { '--accent': '#8b5cf6', '--accent-hi': '#a78bfa', '--accent-dim': 'rgba(139,92,246,0.13)',  '--accent-glow': '0 0 28px rgba(139,92,246,0.20)'  },
-  green:  { '--accent': '#10b981', '--accent-hi': '#34d399', '--accent-dim': 'rgba(16,185,129,0.13)',  '--accent-glow': '0 0 28px rgba(16,185,129,0.20)'  },
-  red:    { '--accent': '#ef4444', '--accent-hi': '#f87171', '--accent-dim': 'rgba(239,68,68,0.13)',   '--accent-glow': '0 0 28px rgba(239,68,68,0.20)'   },
-  orange: { '--accent': '#f97316', '--accent-hi': '#fb923c', '--accent-dim': 'rgba(249,115,22,0.13)',  '--accent-glow': '0 0 28px rgba(249,115,22,0.20)'  },
+  blue:   { '--accent': '#3b82f6', '--accent-hi': '#60a5fa', '--accent-rgb': '59,130,246',  '--accent-dim': 'rgba(59,130,246,0.13)',  '--accent-glow': '0 0 28px rgba(59,130,246,0.20)'  },
+  purple: { '--accent': '#8b5cf6', '--accent-hi': '#a78bfa', '--accent-rgb': '139,92,246',  '--accent-dim': 'rgba(139,92,246,0.13)',  '--accent-glow': '0 0 28px rgba(139,92,246,0.20)'  },
+  green:  { '--accent': '#10b981', '--accent-hi': '#34d399', '--accent-rgb': '16,185,129',  '--accent-dim': 'rgba(16,185,129,0.13)',  '--accent-glow': '0 0 28px rgba(16,185,129,0.20)'  },
+  red:    { '--accent': '#ef4444', '--accent-hi': '#f87171', '--accent-rgb': '239,68,68',   '--accent-dim': 'rgba(239,68,68,0.13)',   '--accent-glow': '0 0 28px rgba(239,68,68,0.20)'   },
+  orange: { '--accent': '#f97316', '--accent-hi': '#fb923c', '--accent-rgb': '249,115,22',  '--accent-dim': 'rgba(249,115,22,0.13)',  '--accent-glow': '0 0 28px rgba(249,115,22,0.20)'  },
 };
 
 function setTheme(name) {
@@ -1598,6 +1603,44 @@ async function fetchClips() {
   }
 }
 
+
+let activePreviewVideo = null;
+
+function stopActivePreview(resetTime = true) {
+  if (!activePreviewVideo) return;
+  try {
+    activePreviewVideo.pause();
+    if (resetTime) activePreviewVideo.currentTime = 0;
+  } catch (_) {}
+  activePreviewVideo = null;
+}
+
+function startPreview(slug) {
+  const card = document.getElementById('card-' + slug);
+  if (!card) return;
+  const vid = card.querySelector('video.preview-video');
+  if (!vid) return;
+
+  if (activePreviewVideo && activePreviewVideo !== vid) {
+    stopActivePreview(true);
+  }
+
+  activePreviewVideo = vid;
+  const maybe = vid.play();
+  if (maybe && typeof maybe.catch === 'function') maybe.catch(() => {});
+}
+
+function stopPreview(slug) {
+  const card = document.getElementById('card-' + slug);
+  const vid = card?.querySelector('video.preview-video');
+  if (!vid) return;
+  try {
+    vid.pause();
+    vid.currentTime = 0;
+  } catch (_) {}
+  if (activePreviewVideo === vid) activePreviewVideo = null;
+}
+
 function renderClips() {
   const grid  = document.getElementById('clips-grid');
   const empty = document.getElementById('clips-empty');
@@ -1607,6 +1650,7 @@ function renderClips() {
   sub.textContent = n === 0 ? 'No clips saved yet' : `${n} clip${n !== 1 ? 's' : ''}`;
   empty.style.display = n === 0 ? 'block' : 'none';
 
+  stopActivePreview(true);
   grid.innerHTML = clips.map(c => cardHTML(c)).join('');
   lucide.createIcons();
 }
@@ -1622,11 +1666,10 @@ function cardHTML(c) {
 
   return `
   <div class="clip-card" id="card-${escAttr(c.slug)}">
-    <div class="thumb-wrap" onclick="openViewer('${escAttr(c.slug)}')" style="cursor:pointer">
+    <div class="thumb-wrap" onclick="openViewer('${escAttr(c.slug)}')" onmouseenter="startPreview('${escAttr(c.slug)}')" onmouseleave="stopPreview('${escAttr(c.slug)}')" style="cursor:pointer">
       ${c.thumb_url
         ? `<img src="${c.thumb_url}" loading="lazy" alt="">
-           <video src="${c.video_url}" muted loop preload="none"
-                  onmouseenter="this.play()" onmouseleave="this.pause();this.currentTime=0"></video>`
+           <video class="preview-video" src="${c.video_url}" muted loop playsinline preload="none"></video>`
         : `<div class="thumb-placeholder"><svg data-lucide="film" width="24" height="24"></svg></div>`}
       ${durStr ? `<span class="clip-dur-badge">${durStr}</span>` : ''}
       ${isNew  ? `<span class="clip-new-badge">NEW</span>`       : ''}
@@ -1981,8 +2024,22 @@ function escAttr(s) { return String(s).replace(/&/g,'&amp;').replace(/'/g,'&#39;
 let viewerSlug       = null;
 let viewerIdx        = -1;
 let viewerHighlights = [];
+let draggingHighlight = null;
+
+function seekViewerTo(seconds) {
+  const vid = document.getElementById('viewer-video');
+  if (!vid) return;
+  const target = Math.max(0, Number(seconds) || 0);
+  try {
+    if (typeof vid.fastSeek === 'function') vid.fastSeek(target);
+    else vid.currentTime = target;
+  } catch (_) {
+    vid.currentTime = target;
+  }
+}
 
 function openViewer(slug) {
+  stopActivePreview(true);
   const idx = clips.findIndex(c => c.slug === slug);
   if (idx < 0) return;
   viewerSlug = slug;
@@ -2002,7 +2059,11 @@ function openViewer(slug) {
     clips.length > 1 ? `${idx + 1} / ${clips.length}` : '';
 
   const vid = document.getElementById('viewer-video');
-  vid.src = c.video_url;
+  if (vid.src !== c.video_url) {
+    vid.pause();
+    vid.src = c.video_url;
+    vid.load();
+  }
   document.getElementById('viewer-progress').style.width = '0%';
   document.getElementById('viewer-playhead').style.left  = '0%';
   document.getElementById('viewer-prev').disabled = idx === 0;
@@ -2014,6 +2075,7 @@ function openViewer(slug) {
 }
 
 function closeViewer() {
+  stopActivePreview(true);
   document.getElementById('viewer-modal').classList.remove('open');
   const vid = document.getElementById('viewer-video');
   vid.pause(); vid.src = '';
@@ -2031,7 +2093,7 @@ function viewerTimelineClick(e) {
   const vid = document.getElementById('viewer-video');
   if (!vid.duration) return;
   const rect = document.getElementById('viewer-timeline').getBoundingClientRect();
-  vid.currentTime = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width)) * vid.duration;
+  seekViewerTo(Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width)) * vid.duration);
 }
 
 (function() {
@@ -2092,8 +2154,9 @@ function renderViewerHighlights() {
     m.className  = 'hl-marker';
     m.style.left = pct + '%';
     m.style.background = color;
-    m.title      = `${hl.label} — ${fmtSec(hl.time, true)}`;
-    m.onclick    = ev => { ev.stopPropagation(); vid.currentTime = hl.time; };
+    m.title      = `${hl.label} — ${fmtSec(hl.time, true)} (drag to move)`;
+    m.onpointerdown = ev => beginHighlightDrag(ev, hl, m);
+    m.onclick    = ev => { if (!draggingHighlight) { ev.stopPropagation(); seekViewerTo(hl.time); } };
     markersEl.appendChild(m);
   });
 
@@ -2124,7 +2187,7 @@ function renderViewerHighlights() {
     const timeEl = document.createElement('span');
     timeEl.className   = 'hl-time';
     timeEl.textContent = fmtSec(hl.time, true);
-    timeEl.onclick     = ev => { ev.stopPropagation(); vid.currentTime = hl.time; };
+    timeEl.onclick     = ev => { ev.stopPropagation(); seekViewerTo(hl.time); };
 
     const labelWrap = document.createElement('span');
     labelWrap.className = 'hl-label-wrap';
@@ -2144,10 +2207,80 @@ function renderViewerHighlights() {
     item.appendChild(timeEl);
     item.appendChild(labelWrap);
     item.appendChild(delBtn);
-    item.onclick = () => { vid.currentTime = hl.time; };
+    item.onclick = () => { seekViewerTo(hl.time); };
     listEl.appendChild(item);
   });
   lucide.createIcons();
+}
+
+function dragTimeFromPointer(ev) {
+  const vid = document.getElementById('viewer-video');
+  const tl  = document.getElementById('viewer-timeline');
+  if (!vid || !tl || !vid.duration) return null;
+  const rect = tl.getBoundingClientRect();
+  const x = Math.max(rect.left, Math.min(rect.right, ev.clientX));
+  const ratio = Math.max(0, Math.min(1, (x - rect.left) / rect.width));
+  return ratio * vid.duration;
+}
+
+function beginHighlightDrag(ev, hl, markerEl) {
+  if (ev.button !== undefined && ev.button !== 0) return;
+  ev.preventDefault();
+  ev.stopPropagation();
+  const t = dragTimeFromPointer(ev);
+  draggingHighlight = { id: hl.id, markerEl, startTime: hl.time, time: t ?? hl.time };
+  markerEl.classList.add('dragging');
+
+  const onMove = moveEv => {
+    if (!draggingHighlight) return;
+    const next = dragTimeFromPointer(moveEv);
+    if (next == null) return;
+    draggingHighlight.time = next;
+    const item = viewerHighlights.find(h => h.id === draggingHighlight.id);
+    if (item) {
+      item.time = Number(next.toFixed(3));
+      viewerHighlights.sort((a, b) => a.time - b.time);
+      renderViewerHighlights();
+    }
+  };
+
+  const onUp = async upEv => {
+    window.removeEventListener('pointermove', onMove, true);
+    window.removeEventListener('pointerup', onUp, true);
+    window.removeEventListener('pointercancel', onUp, true);
+
+    const cur = draggingHighlight;
+    draggingHighlight = null;
+    if (cur?.markerEl) cur.markerEl.classList.remove('dragging');
+
+    if (!cur) return;
+    const finalTime = dragTimeFromPointer(upEv);
+    const applied = Number((finalTime ?? cur.time).toFixed(3));
+    const item = viewerHighlights.find(h => h.id === cur.id);
+    if (item) item.time = applied;
+    viewerHighlights.sort((a, b) => a.time - b.time);
+    renderViewerHighlights();
+
+    if (!viewerSlug) return;
+    try {
+      await fetch(`/api/clips/${viewerSlug}/highlights/${cur.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ time: applied }),
+      });
+      toast(`Highlight moved to ${fmtSec(applied, true)}`, 'ok');
+    } catch (_) {
+      const old = viewerHighlights.find(h => h.id === cur.id);
+      if (old) old.time = cur.startTime;
+      viewerHighlights.sort((a, b) => a.time - b.time);
+      renderViewerHighlights();
+      toast('Failed to move highlight', 'err');
+    }
+  };
+
+  window.addEventListener('pointermove', onMove, true);
+  window.addEventListener('pointerup', onUp, true);
+  window.addEventListener('pointercancel', onUp, true);
 }
 
 function showColorPicker(hlId, currentColor, anchorEl) {
@@ -2316,6 +2449,13 @@ function startRename(slug) {
     const newName = input.value.trim();
     if (!newName || newName === current) {
       input.replaceWith(nameEl);
+      return;
+    }
+    if (newName.includes(' ')) {
+      toast('Clip name cannot contain spaces', 'err');
+      submitted = false;
+      input.focus();
+      input.select();
       return;
     }
     try {


### PR DESCRIPTION
### Motivation
- Add first-class session highlights (marker + audible chime and UI workflows) and enable moving highlights in the viewer. 
- Allow some config changes to be applied live (hotkeys) and make desktop audio capture more reliable by selecting sink monitor sources. 
- Improve thumbnail caching/versioning, preview UX, theming variables and add an opt-in watermark setting to avoid unexpected encoding spikes.

### Description
- Audio: add `HIGHLIGHT_SOUND` and `play_highlight()` to play a single-chime when a session highlight is created. 
- Config & README: add `apply_watermark` boolean (default false) to `RecordingConfig` and update `README.md` example. 
- Hotkeys & main: add `HotkeyListener.clear_bindings()`, centralize hotkey binding in `ViceDaemon._bind_hotkeys()`, and implement `_apply_live_config()` which is wired into the share server to apply live changes (hotkeys/status broadcast). 
- Recorder: add `_desktop_audio_source()` to prefer Pulseaudio/PipeWire sink monitor sources and use it for `wf-recorder`, ffmpeg session/x11capture and segment backends; prefer `gpu-screen-recorder` for direct Wayland sessions and add a helper `_gsr_session_cmd`; only apply watermarking when `apply_watermark` is enabled; fix regex imports/usage. 
- Share server: implement versioned thumbnail cache keys (`_thumb_path`) and `_purge_slug_thumbs`, change `_make_thumb()` to seek slightly into the file and use more robust ffmpeg flags, include cache-bust query in clip JSON `thumb_url`, return media via local relative URLs while keeping public share links, add live-config apply callback handling, validate/forbid spaces in clip rename requests, allow patching highlight time in `_api_patch_highlight`. 
- UI: add theme `--accent-rgb` variables and use them for consistent rgba generation, enable preview video playback on thumbnail hover with a single active preview, set `preload/playsinline` on viewer video, add fast/robust seeking helper `seekViewerTo`, implement draggable highlight markers (pointer events) so highlights can be moved in the viewer and PATCHed to the server, minor CSS/UX tweaks and accessibility improvements. 

### Testing
- No automated tests were added or run as part of this change.

