### PR TITLE
Fix AUR launcher visibility by correcting desktop metadata

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = vice-clipper
 	pkgdesc = Medal.tv-style game clip recorder for Linux — instant replay, session recording, and one-click sharing
 	pkgver = 1.0.3
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/eklonofficial/Vice
 	arch = x86_64
 	license = GPL-3.0-or-later

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Andrew Marin <andrewmarin367@gmail.com>
 pkgname=vice-clipper
 pkgver=1.0.3
-pkgrel=1
+pkgrel=2
 pkgdesc="Medal.tv-style game clip recorder for Linux — instant replay, session recording, and one-click sharing"
 arch=('x86_64')
 url="https://github.com/eklonofficial/Vice"

--- a/vice.desktop
+++ b/vice.desktop
@@ -11,4 +11,3 @@ Categories=Game;Video;Recorder;AudioVideo;
 Keywords=clip;record;game;capture;gameplay;screenshot;streaming;
 StartupNotify=true
 StartupWMClass=Vice
-MimeType=


### PR DESCRIPTION
### Motivation
- Some desktop launchers fail to index malformed desktop entries, and an empty `MimeType=` line can cause the app entry to be omitted from application menus even though the binary (`vice-app`) runs from the terminal.

### Description
- Removed the empty `MimeType=` line from `vice.desktop` to ensure the desktop entry is valid and indexable.
- Bumped `pkgrel` from `1` to `2` in `PKGBUILD` and synchronized the change in `.SRCINFO` so the AUR package revision reflects the fix.

### Testing
- Ran `desktop-file-validate vice.desktop` but the command is not available in this environment, so full validation could not be performed (failed due to missing tool).
- Attempted `makepkg --printsrcinfo` but `makepkg` is not available here, so `.SRCINFO` was updated manually instead (command failed due to missing tool).
- Verified via `git show` and diffs that the `MimeType=` line was removed and `pkgrel=2` is present in both `PKGBUILD` and `.SRCINFO`, which succeeded.