### PR TITLE
Fix global hotkeys for non-input-group users: add udev rule and UI warning

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -8,6 +8,7 @@ url="https://github.com/eklonofficial/Vice"
 license=('GPL-3.0-or-later')
 depends=(
     'python'
+    'systemd'
     'python-evdev'
     'python-aiohttp'
     'python-click'
@@ -52,10 +53,6 @@ package() {
     install -Dm644 assets/vice.svg \
         "$pkgdir/usr/share/icons/hicolor/scalable/apps/vice.svg"
 
-    install -Dm644 /dev/stdin \
-        "$pkgdir/usr/share/doc/vice-clipper/README" <<'DOC'
-Vice requires the user to be in the 'input' group for global hotkeys:
-  sudo usermod -aG input $USER
-Then log out and back in.
-DOC
+    install -Dm644 packaging/vice.rules \
+        "$pkgdir/usr/lib/udev/rules.d/70-vice-input.rules"
 }

--- a/packaging/vice.rules
+++ b/packaging/vice.rules
@@ -1,0 +1,1 @@
+KERNEL=="event*", SUBSYSTEM=="input", TAG+="uaccess"

--- a/vice/hotkey.py
+++ b/vice/hotkey.py
@@ -7,8 +7,9 @@ display server entirely. This means hotkeys work on:
   • Wayland (Hyprland, GNOME, KDE, sway — any compositor)
   • Even TTY sessions
 
-Requirement: the running user must be in the `input` group, or Vice must
-run with appropriate permissions. The installer script handles this.
+Requirement: the running user must have read access to /dev/input/event*
+(typically via the packaged udev rule that tags input devices with uaccess).
+If that rule is missing, hotkeys will not trigger.
 
 Usage:
     listener = HotkeyListener(cfg)
@@ -27,8 +28,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
-from typing import Callable, Coroutine, Optional
+from typing import Callable, Coroutine
 
 import evdev
 from evdev import InputDevice, categorize, ecodes
@@ -50,6 +50,7 @@ class HotkeyListener:
         self._running = False
         # Per-key pending single-tap timer tasks
         self._pending: dict[str, asyncio.Task] = {}
+        self.available = False
 
     def on(self, key_name: str, callback: AsyncCallback) -> None:
         """
@@ -78,11 +79,12 @@ class HotkeyListener:
     async def start(self) -> None:
         """Discover keyboards and spawn a listener task per device."""
         keyboards = _find_keyboards()
+        self.available = bool(keyboards)
         if not keyboards:
             log.warning(
                 "No keyboard devices found in /dev/input/. "
-                "Make sure your user is in the 'input' group: "
-                "sudo usermod -aG input $USER  (then log out/in)"
+                "Ensure the udev uaccess rule is installed, then run: "
+                "sudo udevadm control --reload && sudo udevadm trigger"
             )
             return
 
@@ -188,6 +190,11 @@ def _find_keyboards() -> list[InputDevice]:
             pass
     return devices
 
+
+
+def can_access_hotkeys() -> bool:
+    """Return True when at least one keyboard input device is readable."""
+    return bool(_find_keyboards())
 
 def list_available_keys() -> list[str]:
     """Return all KEY_* names evdev knows about (for documentation/config help)."""

--- a/vice/main.py
+++ b/vice/main.py
@@ -30,7 +30,7 @@ import click
 
 from . import __version__
 from .config import load as load_config, save as save_config, CONFIG_PATH, CONFIG_DIR
-from .hotkey import HotkeyListener, list_available_keys
+from .hotkey import HotkeyListener, can_access_hotkeys, list_available_keys
 from .recorder import create_recorder
 from .share import ShareServer
 from . import audio
@@ -51,6 +51,7 @@ class ViceDaemon:
         self.recorder = create_recorder(self.cfg)
         self.hotkeys  = HotkeyListener()
         self.share:   Optional[ShareServer] = None
+        self.hotkeys_available = can_access_hotkeys()
         self._clip_lock  = asyncio.Lock()
         self._clip_count = 0
         # Session recording state
@@ -86,6 +87,7 @@ class ViceDaemon:
                         "backend": self.recorder.name,
                         "session_active": self._session_active,
                         "clip_key": self.cfg.hotkeys.clip,
+                        "hotkeys_available": self.hotkeys_available,
                     })
                 )
 
@@ -102,6 +104,7 @@ class ViceDaemon:
         )
 
         await self.hotkeys.start()
+        self.hotkeys_available = self.hotkeys.available
         await self.recorder.start()
 
         if self.share:
@@ -109,6 +112,9 @@ class ViceDaemon:
                 self.share.broadcast({
                     "type": "status", "recording": True,
                     "backend": self.recorder.name,
+                    "session_active": self._session_active,
+                    "clip_key": self.cfg.hotkeys.clip,
+                    "hotkeys_available": self.hotkeys_available,
                 })
             )
 
@@ -148,15 +154,17 @@ class ViceDaemon:
                 "backend": self.recorder.name,
                 "session_active": self._session_active,
                 "clip_key": self.cfg.hotkeys.clip,
+                "hotkeys_available": self.hotkeys_available,
             })
 
     def _get_status(self) -> dict:
         return {
             "recording":      True,
-            "backend":        self.recorder.name,
-            "clips":          self._clip_count,
-            "session_active": self._session_active,
-            "clip_key": self.cfg.hotkeys.clip,
+            "backend":          self.recorder.name,
+            "clips":            self._clip_count,
+            "session_active":   self._session_active,
+            "clip_key":         self.cfg.hotkeys.clip,
+            "hotkeys_available": self.hotkeys_available,
         }
 
     async def _shutdown(self, server) -> None:
@@ -278,8 +286,9 @@ class ViceDaemon:
                     "clips":          self._clip_count,
                     "output":         self.cfg.output.directory,
                     "share_url":      self.share.base_url() if self.share else None,
-                    "session_active": self._session_active,
-                    "clip_key":       self.cfg.hotkeys.clip,
+                    "session_active":  self._session_active,
+                    "clip_key":        self.cfg.hotkeys.clip,
+                    "hotkeys_available": self.hotkeys_available,
                 }).encode() + b"\n")
             elif cmd == "url":
                 url = self.share.base_url() if self.share else ""

--- a/vice/ui/index.html
+++ b/vice/ui/index.html
@@ -213,6 +213,29 @@
     .btn-sm { padding: 5px 10px; font-size: 12px; }
     .btn:disabled { opacity: .35; cursor: not-allowed; transform: none; }
 
+
+    .perm-warning {
+      display: none;
+      margin-bottom: 14px;
+      padding: 10px 12px;
+      border-radius: var(--r-sm);
+      border: 1px solid rgba(245, 158, 11, 0.45);
+      background: rgba(245, 158, 11, 0.10);
+      color: #fcd34d;
+      font-size: 12px;
+      line-height: 1.55;
+    }
+    .perm-warning.show { display: block; }
+    .perm-warning code {
+      background: rgba(0,0,0,.35);
+      border: 1px solid rgba(255,255,255,0.12);
+      border-radius: var(--r-xs);
+      padding: 1px 5px;
+      font-size: 11px;
+      color: #fde68a;
+      white-space: nowrap;
+    }
+
     /* ── Clips view ─────────────────────────────────────────────────── */
     #clips-empty {
       text-align: center; padding: 72px 0;
@@ -947,6 +970,15 @@
         </button>
       </div>
 
+
+      <div class="perm-warning" id="hotkey-perm-warning">
+        <strong>Global hotkeys are unavailable.</strong> Vice can still save clips from this button, but keyboard hotkeys cannot read
+        <code>/dev/input/event*</code> right now.
+        Ensure the packaged udev rule is installed, then run
+        <code>sudo udevadm control --reload && sudo udevadm trigger</code>
+        (or log out and back in).
+      </div>
+
       <div id="clips-empty">
         <div class="empty-icon">
           <svg data-lucide="film" width="26" height="26"></svg>
@@ -1473,6 +1505,7 @@ let cfg       = {};
 let ws        = null;
 let recentNew = new Set();
 let tunnelUrl = null;
+let hotkeysAvailable = true;
 
 // Trim state
 let trimSlug  = null;
@@ -1495,6 +1528,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   fetchClips();
   fetchConfig();
+  fetchStatus();
   connectWS();
 
   if (IS_NATIVE) document.getElementById('quit-row').style.display = 'flex';
@@ -1559,6 +1593,7 @@ function handleWS(msg) {
     renderClips();
   } else if (msg.type === 'status') {
     setRecStatus(msg.recording, msg.backend, msg.session_active);
+    applyHotkeyAvailability(msg.hotkeys_available);
   } else if (msg.type === 'tunnel_url') {
     tunnelUrl = msg.url;
     const pill = document.getElementById('tunnel-pill');
@@ -1587,6 +1622,23 @@ function copyTunnelUrl() {
   navigator.clipboard.writeText(tunnelUrl)
     .then(() => toast('Public URL copied!', 'ok'))
     .catch(() => toast('Could not copy', 'err'));
+}
+
+
+async function fetchStatus() {
+  try {
+    const r = await fetch('/api/status');
+    const d = await r.json();
+    setRecStatus(d.recording, d.backend, d.session_active);
+    applyHotkeyAvailability(d.hotkeys_available);
+  } catch (_) {}
+}
+
+function applyHotkeyAvailability(available) {
+  hotkeysAvailable = available !== false;
+  const warn = document.getElementById('hotkey-perm-warning');
+  if (!warn) return;
+  warn.classList.toggle('show', !hotkeysAvailable);
 }
 
 // ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
### Motivation

- Global hotkeys use evdev to read `/dev/input/event*`, which fails silently for users who lack `input`-group/device read access on many distros.  
- The preferred distro-safe fix is to ship a udev rule tagging input devices with `uaccess` so the active logged-in user gets ACLs without changing groups.  

### Description

- Add a packaged udev rule at `packaging/vice.rules` with `KERNEL=="event*", SUBSYSTEM=="input", TAG+="uaccess"` and install it to `/usr/lib/udev/rules.d/70-vice-input.rules` from the packaging script.  
- Update `PKGBUILD` to install the udev rule and include `systemd` in `depends` so `uaccess` is available on typical systems.  
- Extend the hotkey backend: `vice/hotkey.py` now exposes `can_access_hotkeys()` and sets a runtime `available` flag, and logs a specific actionable message suggesting `sudo udevadm control --reload && sudo udevadm trigger` when no readable devices are found.  
- Propagate `hotkeys_available` through the daemon (`vice/main.py`) into outgoing status broadcasts and the status API/IPC so the UI can detect access problems.  
- Add an in-app warning banner and client-side logic in `vice/ui/index.html` that queries `/api/status`, listens for status messages, and shows remediation steps while keeping the manual `Save Clip` button usable.  

### Testing

- Ran `python -m compileall vice` to validate Python code compiles successfully (succeeded).  
- Served the UI with `python -m http.server 8765 --bind 0.0.0.0` and used a Playwright script to load the page and capture a screenshot showing the hotkey warning banner (succeeded and artifact captured).  
- Verified packaging changes by inspecting `PKGBUILD` and the new `packaging/vice.rules` file and confirmed the udev rule contents; no runtime failure observed during the static checks.