### PR TITLE
Add `gsr_args` config and UI to pass extra gpu-screen-recorder flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ encoder         = "auto"   # auto | h264_nvenc | libx264 | hevc_nvenc | h264_vaa
 backend         = "auto"   # auto | gsr | wf-recorder | ffmpeg
 capture_audio   = true
 apply_watermark = false   # enable only if you want watermark text on exports
+gsr_args        = ""      # optional extra gpu-screen-recorder flags, e.g. "-k hevc -bm cbr -q 20000 -fm cfr -a {default_sink_monitor}"
 
 [hotkeys]
 clip = "KEY_F9"
@@ -180,6 +181,8 @@ enabled           = true
 port              = 8765
 cloudflare_tunnel = true
 ```
+
+`recording.gsr_args` supports environment/tilde expansion and a `{default_sink_monitor}` placeholder for desktop audio capture.
 
 ### Troubleshooting
 

--- a/vice/config.py
+++ b/vice/config.py
@@ -43,6 +43,9 @@ class RecordingConfig:
     apply_watermark: bool = False
     # PulseAudio/PipeWire sink name. "default" works for most setups.
     audio_sink: str = "default"
+    # Optional extra flags appended to gpu-screen-recorder commands.
+    # Example: "-k hevc -bm cbr -q 20000 -fm cfr"
+    gsr_args: str = ""
 
 
 @dataclass

--- a/vice/recorder.py
+++ b/vice/recorder.py
@@ -21,6 +21,7 @@ import asyncio
 import logging
 import os
 import re
+import shlex
 import shutil
 import signal
 import stat
@@ -88,6 +89,25 @@ def _run_ok(cmd: list[str]) -> bool:
 
 def _has(tool: str) -> bool:
     return shutil.which(tool) is not None
+
+
+def _extra_gsr_args(raw: str) -> list[str]:
+    """Parse user-provided gpu-screen-recorder CLI args."""
+    if not raw.strip():
+        return []
+
+    # Allow env var + tilde expansion so users can reference shell-style values.
+    expanded = os.path.expanduser(os.path.expandvars(raw))
+
+    try:
+        args = shlex.split(expanded)
+    except ValueError as exc:
+        log.warning("Invalid recording.gsr_args ignored: %s", exc)
+        return []
+
+    # Convenience placeholder for desktop monitor source.
+    monitor = _desktop_audio_source("default")
+    return [arg.replace("{default_sink_monitor}", monitor) for arg in args]
 
 
 def _desktop_audio_source(preferred: str) -> str:
@@ -340,6 +360,7 @@ class Recorder(ABC):
         cmd += ["-c", "mp4"]
         if rc.capture_audio:
             cmd += ["-a", "default_output"]
+        cmd += _extra_gsr_args(rc.gsr_args)
         cmd += ["-o", str(out_path)]
         return cmd
 
@@ -537,6 +558,8 @@ class GSRRecorder(Recorder):
         if rc.capture_audio:
             # 'default_output' captures desktop audio via PipeWire/PulseAudio
             cmd += ["-a", "default_output"]
+
+        cmd += _extra_gsr_args(rc.gsr_args)
 
         # Quality — gsr uses its own quality flags
         # (encoder selection is automatic in gsr based on detected GPU)

--- a/vice/ui/index.html
+++ b/vice/ui/index.html
@@ -1087,6 +1087,16 @@
             <div class="s-label"><strong>Capture Audio</strong><span>Include desktop audio in clips</span></div>
             <label class="toggle"><input type="checkbox" id="s-audio"><span class="toggle-track"></span></label>
           </div>
+
+        </div>
+
+        <!-- Advanced gpu-screen-recorder -->
+        <div class="settings-card">
+          <div class="settings-card-hd"><svg data-lucide="sliders-horizontal"></svg> Advanced (gpu-screen-recorder)</div>
+          <div class="settings-row">
+            <div class="s-label"><strong>Extra Args</strong><span>Optional flags appended to gpu-screen-recorder (example: <code>-k hevc -bm cbr -q 20000 -fm cfr -a {default_sink_monitor}</code>)</span></div>
+            <input type="text" id="s-gsr-args" placeholder="-k hevc -bm cbr -q 20000 -fm cfr -a {default_sink_monitor}">
+          </div>
         </div>
 
         <!-- Hotkeys -->
@@ -1810,6 +1820,7 @@ function populateSettings(c) {
   pick('s-enc',     r.encoder        ?? 'auto');
   pick('s-backend', r.backend        ?? 'auto');
   document.getElementById('s-audio').checked = r.capture_audio !== false;
+  document.getElementById('s-gsr-args').value = r.gsr_args ?? '';
   const clipKey = h.clip ?? 'KEY_F9';
   document.getElementById('s-key').value = clipKey;
   document.getElementById('s-key-btn').textContent = clipKey;
@@ -1833,6 +1844,7 @@ async function saveSettings() {
       encoder:         document.getElementById('s-enc').value,
       backend:         document.getElementById('s-backend').value,
       capture_audio:   document.getElementById('s-audio').checked,
+      gsr_args:        document.getElementById('s-gsr-args').value.trim(),
     },
     hotkeys: { clip: document.getElementById('s-key').value },
     output:  { directory: document.getElementById('s-dir').value },


### PR DESCRIPTION
### Motivation
- Allow advanced users to pass extra command-line flags to `gpu-screen-recorder` for custom quality, codec, or audio source options. 
- Expose the option in the GUI and document tilde/env expansion and a `{default_sink_monitor}` placeholder for capturing desktop audio.

### Description
- Add `recording.gsr_args` to the config dataclass with a default empty string and document it in `README.md` as `gsr_args` with expansion/placeholder semantics. 
- Implement `_extra_gsr_args` which expands env/tilde, parses arguments via `shlex.split`, logs invalid input, and substitutes `{default_sink_monitor}` using `_desktop_audio_source`. 
- Append parsed extra args to both `Recorder._gsr_session_cmd` and `GSRRecorder` command construction so `gpu-screen-recorder` receives the additional flags. 
- Add an advanced UI field `s-gsr-args` to `vice/ui/index.html`, populate it from config on load, and include it in `saveSettings` so the value is persisted.