### PR TITLE
Add gpu-screen-recorder `gsr_args` option and live recording-config restart with UI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ encoder         = "auto"   # auto | h264_nvenc | libx264 | hevc_nvenc | h264_vaa
 backend         = "auto"   # auto | gsr | wf-recorder | ffmpeg
 capture_audio   = true
 apply_watermark = false   # enable only if you want watermark text on exports
+gsr_args        = ""      # optional extra gpu-screen-recorder flags, e.g. "-k hevc -bm cbr -q 20000 -fm cfr -a {default_sink_monitor}"
 
 [hotkeys]
 clip = "KEY_F9"
@@ -180,6 +181,8 @@ enabled           = true
 port              = 8765
 cloudflare_tunnel = true
 ```
+
+`recording.gsr_args` supports environment/tilde expansion and a `{default_sink_monitor}` placeholder for desktop audio capture.
 
 ### Troubleshooting
 

--- a/vice/config.py
+++ b/vice/config.py
@@ -43,6 +43,9 @@ class RecordingConfig:
     apply_watermark: bool = False
     # PulseAudio/PipeWire sink name. "default" works for most setups.
     audio_sink: str = "default"
+    # Optional extra flags appended to gpu-screen-recorder commands.
+    # Example: "-k hevc -bm cbr -q 20000 -fm cfr"
+    gsr_args: str = ""
 
 
 @dataclass

--- a/vice/main.py
+++ b/vice/main.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from dataclasses import asdict
 import os
 import shutil
 import signal
@@ -58,6 +59,7 @@ class ViceDaemon:
         self._session_active   = False
         self._session_path:    Optional[Path] = None
         self._session_highlights: list[dict] = []  # {time, label, color}
+        self._recording_sig = self._recording_signature()
 
     async def run(self) -> None:
         Path("/tmp/vice").mkdir(parents=True, exist_ok=True)
@@ -72,26 +74,7 @@ class ViceDaemon:
             await self.share.start()
 
         # Recorder callback — fires for both normal clips and session clips
-        def _on_clip_saved(path: Path) -> None:
-            self._clip_count += 1
-            click.echo(f"\n[Vice] Clip saved: {path}")
-            if self.share:
-                # Session clips are added to the share server inside _stop_session;
-                # only add here for regular replay-buffer clips (not sessions).
-                if not path.name.startswith("Vice_Session_"):
-                    url = self.share.add_clip(path)
-                    click.echo(f"[Vice] Share URL:  {url}\n")
-                asyncio.create_task(
-                    self.share.broadcast({
-                        "type": "status", "recording": True,
-                        "backend": self.recorder.name,
-                        "session_active": self._session_active,
-                        "clip_key": self.cfg.hotkeys.clip,
-                        "hotkeys_available": self.hotkeys_available,
-                    })
-                )
-
-        self.recorder.on_clip_saved(_on_clip_saved)
+        self.recorder.on_clip_saved(self._on_clip_saved)
 
         # Hotkeys
         self._bind_hotkeys()
@@ -134,6 +117,41 @@ class ViceDaemon:
         await stop_event.wait()
         await self._shutdown(server)
 
+    def _recording_signature(self) -> str:
+        """Stable representation of recording config for live-apply checks."""
+        return json.dumps(asdict(self.cfg.recording), sort_keys=True)
+
+    def _on_clip_saved(self, path: Path) -> None:
+        self._clip_count += 1
+        click.echo(f"\n[Vice] Clip saved: {path}")
+        if self.share:
+            # Session clips are added to the share server inside _stop_session;
+            # only add here for regular replay-buffer clips (not sessions).
+            if not path.name.startswith("Vice_Session_"):
+                url = self.share.add_clip(path)
+                click.echo(f"[Vice] Share URL:  {url}\n")
+            asyncio.create_task(
+                self.share.broadcast({
+                    "type": "status", "recording": True,
+                    "backend": self.recorder.name,
+                    "session_active": self._session_active,
+                    "clip_key": self.cfg.hotkeys.clip,
+                    "hotkeys_available": self.hotkeys_available,
+                })
+            )
+
+    async def _restart_recorder_for_config(self) -> None:
+        """Restart recorder to apply recording settings that require process restart."""
+        if self._session_active:
+            log.info("Recording config changed during active session; applying after session ends")
+            return
+
+        await self.recorder.stop()
+        self.recorder = create_recorder(self.cfg)
+        self.recorder.on_clip_saved(self._on_clip_saved)
+        await self.recorder.start()
+        self._recording_sig = self._recording_signature()
+
     def _bind_hotkeys(self) -> None:
         """(Re)bind runtime hotkeys from current config."""
         self.hotkeys.clear_bindings()
@@ -145,8 +163,12 @@ class ViceDaemon:
             self.hotkeys.on_double(clip_key, self._handle_session_toggle)
 
     async def _apply_live_config(self) -> None:
-        """Apply config changes that can be updated without daemon restart."""
+        """Apply config changes and restart recorder when recording settings changed."""
         self._bind_hotkeys()
+
+        if self._recording_signature() != self._recording_sig:
+            await self._restart_recorder_for_config()
+
         if self.share:
             await self.share.broadcast({
                 "type": "status",

--- a/vice/recorder.py
+++ b/vice/recorder.py
@@ -21,6 +21,7 @@ import asyncio
 import logging
 import os
 import re
+import shlex
 import shutil
 import signal
 import stat
@@ -88,6 +89,25 @@ def _run_ok(cmd: list[str]) -> bool:
 
 def _has(tool: str) -> bool:
     return shutil.which(tool) is not None
+
+
+def _extra_gsr_args(raw: str) -> list[str]:
+    """Parse user-provided gpu-screen-recorder CLI args."""
+    if not raw.strip():
+        return []
+
+    # Allow env var + tilde expansion so users can reference shell-style values.
+    expanded = os.path.expanduser(os.path.expandvars(raw))
+
+    try:
+        args = shlex.split(expanded)
+    except ValueError as exc:
+        log.warning("Invalid recording.gsr_args ignored: %s", exc)
+        return []
+
+    # Convenience placeholder for desktop monitor source.
+    monitor = _desktop_audio_source("default")
+    return [arg.replace("{default_sink_monitor}", monitor) for arg in args]
 
 
 def _desktop_audio_source(preferred: str) -> str:
@@ -340,6 +360,7 @@ class Recorder(ABC):
         cmd += ["-c", "mp4"]
         if rc.capture_audio:
             cmd += ["-a", "default_output"]
+        cmd += _extra_gsr_args(rc.gsr_args)
         cmd += ["-o", str(out_path)]
         return cmd
 
@@ -537,6 +558,8 @@ class GSRRecorder(Recorder):
         if rc.capture_audio:
             # 'default_output' captures desktop audio via PipeWire/PulseAudio
             cmd += ["-a", "default_output"]
+
+        cmd += _extra_gsr_args(rc.gsr_args)
 
         # Quality — gsr uses its own quality flags
         # (encoder selection is automatic in gsr based on detected GPU)

--- a/vice/ui/index.html
+++ b/vice/ui/index.html
@@ -1087,6 +1087,16 @@
             <div class="s-label"><strong>Capture Audio</strong><span>Include desktop audio in clips</span></div>
             <label class="toggle"><input type="checkbox" id="s-audio"><span class="toggle-track"></span></label>
           </div>
+
+        </div>
+
+        <!-- Advanced gpu-screen-recorder -->
+        <div class="settings-card">
+          <div class="settings-card-hd"><svg data-lucide="sliders-horizontal"></svg> Advanced (gpu-screen-recorder)</div>
+          <div class="settings-row">
+            <div class="s-label"><strong>Extra Args</strong><span>Optional flags appended to gpu-screen-recorder (example: <code>-k hevc -bm cbr -q 20000 -fm cfr -a {default_sink_monitor}</code>)</span></div>
+            <input type="text" id="s-gsr-args" placeholder="-k hevc -bm cbr -q 20000 -fm cfr -a {default_sink_monitor}">
+          </div>
         </div>
 
         <!-- Hotkeys -->
@@ -1531,6 +1541,12 @@ document.addEventListener('DOMContentLoaded', () => {
   fetchStatus();
   connectWS();
 
+  const gsrArgsInput = document.getElementById('s-gsr-args');
+  if (gsrArgsInput) {
+    gsrArgsInput.addEventListener('change', () => { saveGsrArgsOnly(); });
+    gsrArgsInput.addEventListener('blur', () => { saveGsrArgsOnly(); });
+  }
+
   if (IS_NATIVE) document.getElementById('quit-row').style.display = 'flex';
 
   const vid = document.getElementById('trim-video');
@@ -1810,6 +1826,7 @@ function populateSettings(c) {
   pick('s-enc',     r.encoder        ?? 'auto');
   pick('s-backend', r.backend        ?? 'auto');
   document.getElementById('s-audio').checked = r.capture_audio !== false;
+  document.getElementById('s-gsr-args').value = r.gsr_args ?? '';
   const clipKey = h.clip ?? 'KEY_F9';
   document.getElementById('s-key').value = clipKey;
   document.getElementById('s-key-btn').textContent = clipKey;
@@ -1833,6 +1850,7 @@ async function saveSettings() {
       encoder:         document.getElementById('s-enc').value,
       backend:         document.getElementById('s-backend').value,
       capture_audio:   document.getElementById('s-audio').checked,
+      gsr_args:        document.getElementById('s-gsr-args').value.trim(),
     },
     hotkeys: { clip: document.getElementById('s-key').value },
     output:  { directory: document.getElementById('s-dir').value },
@@ -1852,6 +1870,19 @@ async function saveSettings() {
     setTimeout(() => el.classList.remove('show'), 2400);
     lucide.createIcons();
   } catch (_) { toast('Failed to save settings', 'err'); }
+}
+
+async function saveGsrArgsOnly() {
+  const gsrArgs = document.getElementById('s-gsr-args').value.trim();
+  try {
+    await fetch('/api/config', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ recording: { gsr_args: gsrArgs } }),
+    });
+  } catch (_) {
+    toast('Failed to save gpu-screen-recorder args', 'err');
+  }
 }
 
 // ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
### Motivation
- Provide a way for users to pass extra command-line flags to `gpu-screen-recorder` for advanced tuning and desktop-audio placeholder use. 
- Allow the daemon to detect when recording-related settings change and restart the recorder to apply those settings without restarting the whole daemon. 
- Expose the new option in the web UI so users can edit and persist the extra args.

### Description
- Add a new `recording.gsr_args: str` field to the config and include documentation in `README.md` describing env/tilde expansion and the `{default_sink_monitor}` placeholder. 
- Parse and sanitize user-provided GSR args in `recorder.py` with `_extra_gsr_args()` (supports `shlex.split`, env/`~` expansion, and placeholder substitution using `_desktop_audio_source`). 
- Append parsed extra args to GSR command lines in both session and continuous GSR command builders. 
- Add UI elements and JS logic in `vice/ui/index.html` to show, save, and live-save `s-gsr-args` via `/api/config`, including `populateSettings`, `saveSettings`, and a new `saveGsrArgsOnly()` handler with event listeners. 
- Implement runtime detection of recording-config changes in `vice/main.py` by computing a stable JSON signature of `cfg.recording`, storing it, and restarting the recorder via `_restart_recorder_for_config()` when the signature differs; refactor `_on_clip_saved` into a method and wire it into recorder lifecycle. 