### PR TITLE
Persist config when live apply fails and return non-fatal response

### DIFF
--- a/vice/share.py
+++ b/vice/share.py
@@ -663,26 +663,33 @@ class ShareServer:
         for field in ("recording", "hotkeys", "output", "sharing"):
             setattr(self.cfg, field, getattr(new_cfg, field))
 
+        apply_error: str | None = None
         if self.apply_config_cb:
             try:
                 await self.apply_config_cb()
             except Exception as exc:
-                # Roll back in-memory config when runtime apply fails.
+                # Keep runtime state stable, but still persist new settings.
                 for field in ("recording", "hotkeys", "output", "sharing"):
                     setattr(self.cfg, field, getattr(old_cfg, field))
 
-                # Re-apply reverted config to restore runtime side effects
-                # such as hotkey bindings and recorder state.
                 try:
                     await self.apply_config_cb()
                 except Exception as rollback_exc:
                     log.warning("Rollback apply failed: %s", rollback_exc)
 
-                log.warning("Live config apply failed: %s", exc)
-                return web.json_response({"ok": False, "error": str(exc)}, status=400)
+                apply_error = str(exc)
+                log.warning("Live config apply failed; settings saved for next restart: %s", exc)
 
         save_cfg(new_cfg)
-        return web.json_response({"ok": True})
+        if apply_error:
+            return web.json_response({
+                "ok": True,
+                "applied": False,
+                "warning": "Settings saved but could not be applied live. Restart Vice to apply them.",
+                "error": apply_error,
+            })
+
+        return web.json_response({"ok": True, "applied": True})
 
     async def _api_status(self, _: web.Request) -> web.Response:
         extra = self.get_status_cb() if self.get_status_cb else {}


### PR DESCRIPTION
### Motivation
- Changing settings (for example `recording.gsr_args`) could fail at runtime apply and cause the UI to show hard save errors like "Failed to save settings" or repeated "failed to save gpu-screen-recorder-args". 
- The intent is to persist valid user changes to disk even if the daemon cannot apply them live, and surface a non-fatal warning to the UI so users do not see misleading failures.

### Description
- Update `_api_set_config` in `vice/share.py` to always persist the new config via `save_cfg(new_cfg)` even when `apply_config_cb()` raises. 
- When live apply fails the code now rolls back in-memory runtime state, attempts to re-apply the reverted state, logs the failure, and captures the error string in `apply_error` instead of returning HTTP 400. 
- The handler returns HTTP 200 with JSON `{ "ok": true, "applied": false, "warning": "...", "error": <msg> }` when apply fails, and `{ "ok": true, "applied": true }` on success, allowing the UI to treat the save as successful but indicate live-apply status.

### Testing
- Ran `python -m compileall vice` to verify the package compiles successfully (passed). 
- Executed a small script that sets `ShareServer.apply_config_cb` to a function that raises and confirmed `_api_set_config` returns HTTP 200 with `{"ok": true, "applied": false, ...}` and logs the live-apply error (observed expected behavior).
