### PR TITLE
Handle stale daemon socket and surface live-config apply failures

### DIFF
--- a/vice/app.py
+++ b/vice/app.py
@@ -108,13 +108,43 @@ def _load_user_systemd_env() -> None:
         log.info("Loaded graphical env vars from systemd user env: %s", ", ".join(loaded))
 
 
+def _daemon_responds(timeout: float = 1.0) -> bool:
+    """Return True when the Unix socket accepts an IPC request."""
+    if not SOCKET_FILE.exists():
+        return False
+
+    async def _probe() -> bool:
+        try:
+            reader, writer = await asyncio.wait_for(
+                asyncio.open_unix_connection(str(SOCKET_FILE)),
+                timeout=timeout,
+            )
+            writer.write(b"status\n")
+            await writer.drain()
+            resp = await asyncio.wait_for(reader.readline(), timeout=timeout)
+            writer.close()
+            await writer.wait_closed()
+            return bool(resp)
+        except Exception:
+            return False
+
+    return asyncio.run(_probe())
+
+
 def _start_daemon() -> None:
     """Launch the daemon as a detached background process (no-op if running)."""
     _load_user_systemd_env()
 
     if SOCKET_FILE.exists():
-        log.info("Daemon already running (socket found)")
-        return
+        if _daemon_responds():
+            log.info("Daemon already running (socket is responsive)")
+            return
+        log.warning("Found stale daemon socket at %s; removing it", SOCKET_FILE)
+        try:
+            SOCKET_FILE.unlink()
+        except OSError as exc:
+            log.error("Could not remove stale socket %s: %s", SOCKET_FILE, exc)
+            raise
     cmd = _vice_cmd() + ["start", "--no-open-ui"]
     log.info("Starting daemon: %s", " ".join(cmd))
     try:

--- a/vice/main.py
+++ b/vice/main.py
@@ -395,8 +395,17 @@ def start(debug: bool, open_ui: bool) -> None:
     )
 
     if SOCKET_FILE.exists():
-        click.echo("Vice is already running. Use `vice stop` or `vice status`.", err=True)
-        sys.exit(1)
+        resp = asyncio.run(_ipc("status", timeout=1.5))
+        if resp is not None:
+            click.echo("Vice is already running. Use `vice stop` or `vice status`.", err=True)
+            sys.exit(1)
+
+        log.warning("Found stale IPC socket at %s, removing it", SOCKET_FILE)
+        try:
+            SOCKET_FILE.unlink()
+        except OSError as exc:
+            click.echo(f"Found stale socket at {SOCKET_FILE}, but could not remove it: {exc}", err=True)
+            sys.exit(1)
 
     daemon = ViceDaemon()
 

--- a/vice/share.py
+++ b/vice/share.py
@@ -663,26 +663,33 @@ class ShareServer:
         for field in ("recording", "hotkeys", "output", "sharing"):
             setattr(self.cfg, field, getattr(new_cfg, field))
 
+        apply_error: str | None = None
         if self.apply_config_cb:
             try:
                 await self.apply_config_cb()
             except Exception as exc:
-                # Roll back in-memory config when runtime apply fails.
+                # Keep runtime state stable, but still persist new settings.
                 for field in ("recording", "hotkeys", "output", "sharing"):
                     setattr(self.cfg, field, getattr(old_cfg, field))
 
-                # Re-apply reverted config to restore runtime side effects
-                # such as hotkey bindings and recorder state.
                 try:
                     await self.apply_config_cb()
                 except Exception as rollback_exc:
                     log.warning("Rollback apply failed: %s", rollback_exc)
 
-                log.warning("Live config apply failed: %s", exc)
-                return web.json_response({"ok": False, "error": str(exc)}, status=400)
+                apply_error = str(exc)
+                log.warning("Live config apply failed; settings saved for next restart: %s", exc)
 
         save_cfg(new_cfg)
-        return web.json_response({"ok": True})
+        if apply_error:
+            return web.json_response({
+                "ok": True,
+                "applied": False,
+                "warning": "Settings saved but could not be applied live. Restart Vice to apply them.",
+                "error": apply_error,
+            })
+
+        return web.json_response({"ok": True, "applied": True})
 
     async def _api_status(self, _: web.Request) -> web.Response:
         extra = self.get_status_cb() if self.get_status_cb else {}


### PR DESCRIPTION
### Motivation
- Avoid failing to start or misreporting the daemon when a stale IPC socket file exists and the daemon is not actually responsive.
- Ensure configuration updates are persisted even when live application of new settings fails, and communicate that state to the caller.

### Description
- Added `_daemon_responds` which probes the Unix socket with an IPC `status` request and returns whether the daemon accepts requests, and used it from `_start_daemon` to detect a stale but unresponsive socket before removing it in `vice/app.py`.
- Improved `_start_daemon` logging and error handling to remove a stale socket and raise a clear error when it cannot be unlinked, and kept `start` detached via `subprocess.Popen` on launch in `vice/app.py`.
- Changed the CLI `start` command in `vice/main.py` to probe the socket via `_ipc("status")` before exiting, and to remove a stale socket with proper error reporting when removal fails.
- Updated `ShareServer` config application in `vice/share.py` to persist new settings even if `apply_config_cb` fails, roll back in-memory runtime state, attempt to re-apply the reverted runtime config, and return a JSON payload indicating whether settings were applied live with an `applied` flag and `warning`/`error` details.

### Testing
- Ran the existing unit test suite and IPC-related integration checks, and they completed successfully.
- Verified that starting when a responsive daemon exists still prevents duplicate starts and that a stale socket is removed and replaced during start.
