### PR TITLE
Forward app termination to daemon, sanitize GSR args, robust trimming, and restart-required UI

### DIFF
--- a/vice/app.py
+++ b/vice/app.py
@@ -8,8 +8,9 @@ Behaviour:
   • Waits for the HTTP server to be ready, then opens a native window.
   • Exposes a JS API so the UI can call vice.quit() to stop the daemon
     and close the window cleanly.
-  • Closing the window WITHOUT calling vice.quit() leaves the daemon
-    running in the background (recording continues, hotkey still works).
+  • Closing the window without vice.quit() keeps recording running.
+  • Sending SIGTERM to vice-app (for example: killall vice-app) now
+    forwards a clean stop request to the daemon before exit.
   • Re-launching vice-app when the daemon is already running just opens
     a new window connected to the existing session.
 
@@ -24,6 +25,7 @@ import asyncio
 import logging
 import os
 import shutil
+import signal
 import subprocess
 import sys
 import time
@@ -54,6 +56,15 @@ def _setup_logging() -> None:
 
 
 log = logging.getLogger("vice-app")
+
+
+def _handle_app_terminate(signum: int, _frame) -> None:
+    """Stop daemon when vice-app is terminated externally."""
+    log.info("Received signal %s, stopping daemon before exit", signum)
+    try:
+        _stop_daemon()
+    finally:
+        raise SystemExit(0)
 
 
 # ── helpers ───────────────────────────────────────────────────────────────────
@@ -191,6 +202,8 @@ def _wait_for_server(url: str, timeout: float = 20.0) -> bool:
 
 def main() -> None:
     _setup_logging()
+    signal.signal(signal.SIGTERM, _handle_app_terminate)
+    signal.signal(signal.SIGINT, _handle_app_terminate)
     log.info("vice-app starting (python=%s)", sys.executable)
 
     try:

--- a/vice/recorder.py
+++ b/vice/recorder.py
@@ -98,6 +98,9 @@ def _extra_gsr_args(raw: str) -> list[str]:
 
     # Allow env var + tilde expansion so users can reference shell-style values.
     expanded = os.path.expanduser(os.path.expandvars(raw))
+    monitor = _desktop_audio_source("default")
+    expanded = expanded.replace("$(pactl get-default-sink).monitor", monitor)
+    expanded = expanded.replace("(pactl get-default-sink).monitor", monitor)
 
     try:
         args = shlex.split(expanded)
@@ -106,9 +109,40 @@ def _extra_gsr_args(raw: str) -> list[str]:
         return []
 
     # Convenience placeholder for desktop monitor source.
-    monitor = _desktop_audio_source("default")
-    return [arg.replace("{default_sink_monitor}", monitor) for arg in args]
+    replaced: list[str] = []
+    for arg in args:
+        val = arg.replace("{default_sink_monitor}", monitor)
+        val = val.replace("$(pactl get-default-sink).monitor", monitor)
+        val = val.replace("(pactl get-default-sink).monitor", monitor)
+        replaced.append(val)
+    return replaced
 
+
+
+
+def _gsr_has_any_flag(args: list[str], *flags: str) -> bool:
+    for arg in args:
+        for f in flags:
+            if arg == f or arg.startswith(f + "="):
+                return True
+    return False
+
+
+def _gsr_sanitize_args(args: list[str], blocked_flags: set[str]) -> list[str]:
+    """Drop flags that Vice manages internally to avoid conflicting values."""
+    out: list[str] = []
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg in blocked_flags:
+            i += 2
+            continue
+        if any(arg.startswith(f + "=") for f in blocked_flags):
+            i += 1
+            continue
+        out.append(arg)
+        i += 1
+    return out
 
 def _desktop_audio_source(preferred: str) -> str:
     """
@@ -354,13 +388,19 @@ class Recorder(ABC):
 
     @staticmethod
     def _gsr_session_cmd(out_path: Path, rc) -> list[str]:
+        extra = _gsr_sanitize_args(_extra_gsr_args(rc.gsr_args), {"-o", "-r"})
         cmd = ["gpu-screen-recorder"]
-        cmd += ["-w", "screen" if _is_wayland() else os.environ.get("DISPLAY", ":0")]
-        cmd += ["-f", str(rc.fps)]
-        cmd += ["-c", "mp4"]
-        if rc.capture_audio:
+
+        if not _gsr_has_any_flag(extra, "-w"):
+            cmd += ["-w", "screen" if _is_wayland() else os.environ.get("DISPLAY", ":0")]
+        if not _gsr_has_any_flag(extra, "-f"):
+            cmd += ["-f", str(rc.fps)]
+        if not _gsr_has_any_flag(extra, "-c"):
+            cmd += ["-c", "mp4"]
+        if rc.capture_audio and not _gsr_has_any_flag(extra, "-a"):
             cmd += ["-a", "default_output"]
-        cmd += _extra_gsr_args(rc.gsr_args)
+
+        cmd += extra
         cmd += ["-o", str(out_path)]
         return cmd
 
@@ -446,24 +486,48 @@ async def _trim_to_last_n_seconds(path: Path, seconds: int) -> Path:
 
     start = total - seconds
     tmp = path.with_suffix(".trim.mp4")
-    cmd = [
-        "ffmpeg", "-hide_banner", "-loglevel", "error",
-        "-ss", str(start), "-i", str(path),
-        "-t", str(seconds), "-c", "copy", "-movflags", "+faststart",
-        "-y", str(tmp),
-    ]
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=asyncio.subprocess.DEVNULL,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        _, stderr = await asyncio.wait_for(proc.communicate(), timeout=60)
-        if proc.returncode != 0:
-            log.error("ffmpeg trim failed: %s", stderr.decode())
-            return path  # return original on failure
-    except asyncio.TimeoutError:
-        log.error("ffmpeg trim timed out")
+    def _copy_trim_cmd() -> list[str]:
+        return [
+            "ffmpeg", "-hide_banner", "-loglevel", "error",
+            "-ss", str(start), "-i", str(path),
+            "-t", str(seconds), "-c", "copy", "-movflags", "+faststart",
+            "-y", str(tmp),
+        ]
+
+    def _reencode_trim_cmd() -> list[str]:
+        return [
+            "ffmpeg", "-hide_banner", "-loglevel", "error",
+            "-ss", str(start), "-i", str(path),
+            "-t", str(seconds),
+            "-c:v", "libx264", "-preset", "veryfast", "-crf", "23",
+            "-c:a", "aac", "-b:a", "128k",
+            "-movflags", "+faststart",
+            "-y", str(tmp),
+        ]
+
+    async def _run_trim(cmd: list[str], timeout: int) -> tuple[bool, str]:
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            _, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+            err = stderr.decode() if stderr else ""
+            return proc.returncode == 0, err
+        except asyncio.TimeoutError:
+            return False, "trim command timed out"
+
+    ok, err = await _run_trim(_copy_trim_cmd(), 60)
+    if not ok:
+        log.warning("ffmpeg copy trim failed, retrying with re-encode: %s", err)
+        ok, err = await _run_trim(_reencode_trim_cmd(), 120)
+        if not ok:
+            log.error("ffmpeg trim failed: %s", err)
+            return path
+
+    if not tmp.exists():
+        log.error("ffmpeg trim did not produce output file")
         return path
 
     # Replace original with trimmed version
@@ -531,39 +595,34 @@ class GSRRecorder(Recorder):
 
     def _build_cmd(self) -> list[str]:
         rc = self.cfg.recording
+        extra = _gsr_sanitize_args(_extra_gsr_args(rc.gsr_args), {"-o"})
         cmd = ["gpu-screen-recorder"]
 
-        # Window/screen target
-        if _is_wayland():
-            # On Wayland, 'screen' captures all outputs; specific output names also work.
-            cmd += ["-w", "screen"]
-        else:
-            display = os.environ.get("DISPLAY", ":0")
-            cmd += ["-w", display]
+        # Allow manual overrides through recording.gsr_args.
+        if not _gsr_has_any_flag(extra, "-w"):
+            if _is_wayland():
+                cmd += ["-w", "screen"]
+            else:
+                display = os.environ.get("DISPLAY", ":0")
+                cmd += ["-w", display]
 
-        # Frame rate
-        cmd += ["-f", str(rc.fps)]
+        if not _gsr_has_any_flag(extra, "-f"):
+            cmd += ["-f", str(rc.fps)]
 
-        # Replay buffer duration
-        cmd += ["-r", str(rc.buffer_duration)]
+        if not _gsr_has_any_flag(extra, "-r"):
+            cmd += ["-r", str(rc.buffer_duration)]
+
+        if not _gsr_has_any_flag(extra, "-c"):
+            cmd += ["-c", "mp4"]
+
+        if rc.capture_audio and not _gsr_has_any_flag(extra, "-a"):
+            cmd += ["-a", "default_output"]
+
+        cmd += extra
 
         # Output directory (gsr writes files here on SIGUSR1)
         self._out_dir.mkdir(parents=True, exist_ok=True)
         cmd += ["-o", str(self._out_dir)]
-
-        # Container / codec
-        cmd += ["-c", "mp4"]
-
-        # Audio
-        if rc.capture_audio:
-            # 'default_output' captures desktop audio via PipeWire/PulseAudio
-            cmd += ["-a", "default_output"]
-
-        cmd += _extra_gsr_args(rc.gsr_args)
-
-        # Quality — gsr uses its own quality flags
-        # (encoder selection is automatic in gsr based on detected GPU)
-
         return cmd
 
     async def start(self) -> None:

--- a/vice/share.py
+++ b/vice/share.py
@@ -619,12 +619,13 @@ class ShareServer:
         return web.json_response({"ok": True})
 
     async def _api_get_config(self, _: web.Request) -> web.Response:
-        return web.json_response(asdict(self.cfg))
+        from .config import load as load_cfg
+        return web.json_response(asdict(load_cfg()))
 
     async def _api_set_config(self, req: web.Request) -> web.Response:
         from .config import (
             Config, RecordingConfig, HotkeyConfig, OutputConfig, SharingConfig,
-            save as save_cfg,
+            load as load_cfg, save as save_cfg,
         )
 
         body = await req.json()
@@ -637,7 +638,10 @@ class ShareServer:
                     base[k] = v
             return base
 
-        merged = _merge(asdict(self.cfg), body)
+        # Merge onto the persisted config so partial saves never depend on
+        # transient in-memory rollback state.
+        persisted_cfg = load_cfg()
+        merged = _merge(asdict(persisted_cfg), body)
 
         new_cfg = Config(
             recording=RecordingConfig(**{
@@ -658,6 +662,10 @@ class ShareServer:
             }),
         )
         old_cfg = copy.deepcopy(self.cfg)
+        restart_required = (
+            old_cfg.sharing != new_cfg.sharing
+            or old_cfg.recording.gsr_args != new_cfg.recording.gsr_args
+        )
 
         # Apply live (some settings still require daemon restart, e.g. recorder backend).
         for field in ("recording", "hotkeys", "output", "sharing"):
@@ -668,7 +676,7 @@ class ShareServer:
             try:
                 await self.apply_config_cb()
             except Exception as exc:
-                # Keep runtime state stable, but still persist new settings.
+                # Keep runtime state stable and reject invalid live changes.
                 for field in ("recording", "hotkeys", "output", "sharing"):
                     setattr(self.cfg, field, getattr(old_cfg, field))
 
@@ -680,16 +688,23 @@ class ShareServer:
                 apply_error = str(exc) or exc.__class__.__name__
                 log.warning("Live config apply failed; settings saved for next restart: %s", exc)
 
+        # Always persist validated settings, even when live apply fails.
+        # This keeps restart-intended config changes from being lost.
         save_cfg(new_cfg)
+
         if apply_error:
             return web.json_response({
                 "ok": True,
                 "applied": False,
-                "warning": "Settings saved but could not be applied live. Restart Vice to apply them.",
+                "restart_required": True,
+                "warning": "Settings saved for next restart. Restart Vice to apply them.",
                 "error": apply_error,
             })
 
-        return web.json_response({"ok": True, "applied": True})
+        payload = {"ok": True, "applied": True, "restart_required": restart_required}
+        if restart_required:
+            payload["warning"] = "Some sharing settings require a full app restart to take effect."
+        return web.json_response(payload)
 
     async def _api_status(self, _: web.Request) -> web.Response:
         extra = self.get_status_cb() if self.get_status_cb else {}

--- a/vice/ui/index.html
+++ b/vice/ui/index.html
@@ -615,6 +615,33 @@
     .tutorial-step-text span  { font-size: 11px; color: var(--muted); }
     .tutorial-footer { display: flex; justify-content: flex-end; }
 
+    
+    /* ── Restart-required popup ───────────────────────────────────── */
+    #restart-modal {
+      position: fixed; inset: 0; display: grid; place-items: center;
+      background: rgba(5,8,14,.72); z-index: 120;
+    }
+    #restart-modal.hidden { display: none; }
+    .restart-box {
+      width: min(460px, calc(100% - 28px));
+      background: var(--surface-2);
+      border: 1px solid var(--border-hi);
+      border-radius: 14px;
+      box-shadow: 0 20px 60px rgba(0,0,0,.55);
+      padding: 16px 16px 14px;
+      display: grid; gap: 12px;
+    }
+    .restart-title { font-size: 16px; font-weight: 700; }
+    .restart-sub { font-size: 13px; color: var(--muted); line-height: 1.45; }
+    .restart-cmd {
+      font: 600 12px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
+      border: 1px solid var(--border); border-radius: 10px;
+      background: rgba(0,0,0,.25); padding: 10px 12px;
+      user-select: all;
+    }
+    .restart-actions { display: flex; justify-content: flex-end; gap: 8px; }
+
+
     /* ── Trim modal ─────────────────────────────────────────────────── */
     .backdrop {
       position: fixed; inset: 0;
@@ -1243,6 +1270,21 @@
 </div>
 
 <!-- ── Tutorial Modal (first run only) ────────────────────────────── -->
+
+<div id="restart-modal" class="hidden">
+  <div class="restart-box" role="dialog" aria-modal="true" aria-labelledby="restart-title">
+    <div class="restart-title" id="restart-title">Restart required</div>
+    <div class="restart-sub">
+      Some saved settings apply only after Vice fully restarts. Run this command, then launch Vice again.
+    </div>
+    <div class="restart-cmd" id="restart-cmd">killall vice-app</div>
+    <div class="restart-actions">
+      <button class="btn" onclick="copyRestartCmd()"><svg data-lucide="copy"></svg> Copy command</button>
+      <button class="btn btn-primary" onclick="closeRestartModal()">Got it</button>
+    </div>
+  </div>
+</div>
+
 <div id="tutorial-modal" class="hidden">
   <div class="tutorial-box">
     <h2>Welcome to Vice</h2>
@@ -1516,10 +1558,8 @@ let ws        = null;
 let recentNew = new Set();
 let tunnelUrl = null;
 let hotkeysAvailable = true;
-let _gsrArgsSaveTimer = null;
-let _gsrArgsSaveInFlight = false;
-let _gsrArgsSavePending = null;
 let _lastSavedGsrArgs = null;
+let _lastRestartPromptedGsrArgs = null;
 
 // Trim state
 let trimSlug  = null;
@@ -1545,30 +1585,6 @@ document.addEventListener('DOMContentLoaded', () => {
   fetchStatus();
   connectWS();
 
-  const gsrArgsInput = document.getElementById('s-gsr-args');
-  if (gsrArgsInput) {
-    gsrArgsInput.addEventListener('input', () => {
-      clearTimeout(_gsrArgsSaveTimer);
-      _gsrArgsSaveTimer = setTimeout(() => { saveGsrArgsOnly(); }, 600);
-    });
-    gsrArgsInput.addEventListener('change', () => {
-      clearTimeout(_gsrArgsSaveTimer);
-      saveGsrArgsOnly();
-    });
-    gsrArgsInput.addEventListener('blur', () => {
-      clearTimeout(_gsrArgsSaveTimer);
-      saveGsrArgsOnly();
-    });
-  }
-
-  window.addEventListener('beforeunload', () => {
-    const el = document.getElementById('s-gsr-args');
-    if (!el) return;
-    const payload = JSON.stringify({ recording: { gsr_args: el.value.trim() } });
-    if (navigator.sendBeacon) {
-      navigator.sendBeacon('/api/config', new Blob([payload], { type: 'application/json' }));
-    }
-  });
 
   if (IS_NATIVE) document.getElementById('quit-row').style.display = 'flex';
 
@@ -1755,13 +1771,20 @@ function cardHTML(c) {
     : '';
   const isNew = recentNew.has(c.slug);
 
+  const hoverHandlers = IS_NATIVE
+    ? ''
+    : `onmouseenter="startPreview('${escAttr(c.slug)}')" onmouseleave="stopPreview('${escAttr(c.slug)}')"`;
+  const mediaHtml = c.thumb_url
+    ? (IS_NATIVE
+      ? `<img src="${c.thumb_url}" loading="lazy" alt="">`
+      : `<img src="${c.thumb_url}" loading="lazy" alt="">
+           <video class="preview-video" src="${c.video_url}" muted loop playsinline preload="none"></video>`)
+    : `<div class="thumb-placeholder"><svg data-lucide="film" width="24" height="24"></svg></div>`;
+
   return `
   <div class="clip-card" id="card-${escAttr(c.slug)}">
-    <div class="thumb-wrap" onclick="openViewer('${escAttr(c.slug)}')" onmouseenter="startPreview('${escAttr(c.slug)}')" onmouseleave="stopPreview('${escAttr(c.slug)}')" style="cursor:pointer">
-      ${c.thumb_url
-        ? `<img src="${c.thumb_url}" loading="lazy" alt="">
-           <video class="preview-video" src="${c.video_url}" muted loop playsinline preload="none"></video>`
-        : `<div class="thumb-placeholder"><svg data-lucide="film" width="24" height="24"></svg></div>`}
+    <div class="thumb-wrap" onclick="openViewer('${escAttr(c.slug)}')" ${hoverHandlers} style="cursor:pointer">
+      ${mediaHtml}
       ${durStr ? `<span class="clip-dur-badge">${durStr}</span>` : ''}
       ${isNew  ? `<span class="clip-new-badge">NEW</span>`       : ''}
     </div>
@@ -1815,6 +1838,33 @@ function copyLink(url) {
   navigator.clipboard.writeText(url)
     .then(() => toast('Share link copied!', 'ok'))
     .catch(() => toast('Could not copy link', 'err'));
+}
+
+
+function showRestartModal() {
+  const modal = document.getElementById('restart-modal');
+  if (!modal) return;
+  modal.classList.remove('hidden');
+  lucide.createIcons();
+}
+
+function closeRestartModal() {
+  document.getElementById('restart-modal')?.classList.add('hidden');
+}
+
+function copyRestartCmd() {
+  const cmd = 'killall vice-app';
+  navigator.clipboard.writeText(cmd)
+    .then(() => toast('Restart command copied', 'ok'))
+    .catch(() => toast('Could not copy command', 'err'));
+}
+
+function maybeShowGsrRestartPrompt(prevArgs, savedArgs) {
+  const backend = document.getElementById('s-backend')?.value || (cfg.recording?.backend ?? 'auto');
+  if (!savedArgs || savedArgs === prevArgs || savedArgs === _lastRestartPromptedGsrArgs) return;
+  if (backend !== 'gsr' && backend !== 'auto') return;
+  _lastRestartPromptedGsrArgs = savedArgs;
+  showRestartModal();
 }
 
 // ═══════════════════════════════════════════════════════════════════
@@ -1884,54 +1934,29 @@ async function saveSettings() {
     },
   };
   try {
+    const prevGsrArgs = _lastSavedGsrArgs;
     const resp = await fetch('/api/config', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     });
-    if (!resp.ok) {
-      const err = await resp.json().catch(() => ({}));
-      throw new Error(err.error || 'save failed');
+    const data = await resp.json().catch(() => ({}));
+    if (!resp.ok || data.ok === false) {
+      throw new Error(data.error || 'save failed');
     }
     _lastSavedGsrArgs = document.getElementById('s-gsr-args').value.trim();
+    if (data.applied === false && data.warning) {
+      toast(data.warning, 'err');
+    }
+    if (data.restart_required) {
+      showRestartModal();
+    }
+    maybeShowGsrRestartPrompt(prevGsrArgs, _lastSavedGsrArgs);
     const el = document.getElementById('saved-msg');
     el.classList.add('show');
     setTimeout(() => el.classList.remove('show'), 2400);
     lucide.createIcons();
   } catch (_) { toast('Failed to save settings', 'err'); }
-}
-
-async function saveGsrArgsOnly() {
-  const gsrArgs = document.getElementById('s-gsr-args').value.trim();
-
-  if (gsrArgs === _lastSavedGsrArgs && !_gsrArgsSaveInFlight) return;
-  if (_gsrArgsSaveInFlight) {
-    _gsrArgsSavePending = gsrArgs;
-    return;
-  }
-
-  _gsrArgsSaveInFlight = true;
-  try {
-    const resp = await fetch('/api/config', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ recording: { gsr_args: gsrArgs } }),
-    });
-    if (!resp.ok) {
-      const err = await resp.json().catch(() => ({}));
-      throw new Error(err.error || 'save failed');
-    }
-    _lastSavedGsrArgs = gsrArgs;
-  } catch (_) {
-    toast('Failed to save gpu-screen-recorder args', 'err');
-  } finally {
-    _gsrArgsSaveInFlight = false;
-    const pending = _gsrArgsSavePending;
-    _gsrArgsSavePending = null;
-    if (pending !== null && pending !== _lastSavedGsrArgs) {
-      saveGsrArgsOnly();
-    }
-  }
 }
 
 // ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
### Motivation
- Ensure vice-app forwards external termination (SIGTERM/SIGINT) to the daemon so the recorder stops cleanly before the app exits.
- Prevent gpu-screen-recorder CLI arg conflicts by letting users override arguments without clobbering flags managed by Vice.
- Make ffmpeg trimming more reliable by falling back to re-encoding when stream-copy trimming fails.
- Provide clearer UX when saved settings require a full restart and persist validated settings to disk.

### Description
- Add signal handlers in `vice/app.py` to catch `SIGTERM` and `SIGINT` and request the daemon stop before exiting (`_handle_app_terminate`).
- Improve `vice/recorder.py` by expanding and normalizing user-provided `gsr_args`, replacing sink monitor placeholders, adding `_gsr_has_any_flag` and `_gsr_sanitize_args` to detect and drop flags that the daemon manages, and using sanitized/merged args when building GSR and widget session commands.
- Change `_trim_to_last_n_seconds` to attempt a fast stream-copy trim first and retry with a re-encode command on failure, with timeouts and better logging for failures.
- Update `vice/share.py` `_api_get_config` to return the persisted config, merge posted changes onto the persisted config for partial updates, attempt live apply with rollback on failure, always persist the validated config, and return `applied`/`restart_required` indicators in the API response.
- Add a restart-required modal and related UI logic to `vice/ui/index.html` to show a prompt when saved changes require a full restart, copyable restart command, and adjustments to clip preview markup and behavior.

### Testing
- No automated tests were run for this change.