### PR TITLE
Theme color embeds

### DIFF
--- a/vice/config.py
+++ b/vice/config.py
@@ -81,8 +81,8 @@ class SharingConfig:
     cloudflare_tunnel: bool = True
     # Override the public base URL shown in share links (e.g. if behind reverse proxy).
     base_url: Optional[str] = None
-    # Theme color for embeded links. Default is blue.
-    theme_color: str = '#3b82f6'
+    # Theme color for embeded links. Default is vice blue.
+    theme_color: str = 'blue'
 
 
 @dataclass

--- a/vice/config.py
+++ b/vice/config.py
@@ -81,6 +81,8 @@ class SharingConfig:
     cloudflare_tunnel: bool = True
     # Override the public base URL shown in share links (e.g. if behind reverse proxy).
     base_url: Optional[str] = None
+    # Theme color for embeded links. Default is blue.
+    theme_color: str = '#3b82f6'
 
 
 @dataclass

--- a/vice/main.py
+++ b/vice/main.py
@@ -90,6 +90,7 @@ class ViceDaemon:
             self.share.trigger_clip_cb = self._handle_clip_hotkey
             self.share.get_status_cb   = self._get_status
             self.share.apply_config_cb = self._apply_live_config
+            self.share._theme = self.cfg.sharing.theme_color
             try:
                 await self.share.start()
             except Exception:

--- a/vice/share.py
+++ b/vice/share.py
@@ -181,7 +181,7 @@ _EMBED_PAGE = """\
   <meta name="twitter:player"           content="{video_url}">
   <meta name="twitter:player:width"     content="{width}">
   <meta name="twitter:player:height"    content="{height}">
-  <meta name="theme_color"              content="{theme}">
+  <meta name="theme-color"              content="{theme}">
   <title>{title}</title>
   <style>
     body{{margin:0;background:#000;display:flex;align-items:center;

--- a/vice/share.py
+++ b/vice/share.py
@@ -207,7 +207,7 @@ class ShareServer:
         self._public_runner: Optional[web.AppRunner] = None
         self._public_site: Optional[web.TCPSite] = None
         self._legacy_public_site: Optional[web.TCPSite] = None
-        self._theme: str
+        self._theme: str = "blue"
 
         # slug → Path  (populated from disk on start + runtime additions)
         self._clips: dict[str, Path] = {}

--- a/vice/share.py
+++ b/vice/share.py
@@ -156,6 +156,13 @@ async def _make_thumb(path: Path) -> Path:
         pass
     return thumb
 
+_THEMES = {
+    "blue":  '#3b82f6',
+    "purple": '#8b5cf6',
+    "green":  '#10b981',
+    "red":    '#ef4444', 
+    "orange": '#f97316'
+    }
 
 _EMBED_PAGE = """\
 <!DOCTYPE html>
@@ -174,6 +181,7 @@ _EMBED_PAGE = """\
   <meta name="twitter:player"           content="{video_url}">
   <meta name="twitter:player:width"     content="{width}">
   <meta name="twitter:player:height"    content="{height}">
+  <meta name="theme_color"              content="{theme}">
   <title>{title}</title>
   <style>
     body{{margin:0;background:#000;display:flex;align-items:center;
@@ -442,6 +450,7 @@ class ShareServer:
             thumb_url=f"{base}/t/{slug}",
             width=meta.get("width", 1920),
             height=meta.get("height", 1080),
+            theme=_THEMES[self.cfg.share.theme_color]
         )
         return web.Response(text=html, content_type="text/html")
 

--- a/vice/share.py
+++ b/vice/share.py
@@ -207,6 +207,7 @@ class ShareServer:
         self._public_runner: Optional[web.AppRunner] = None
         self._public_site: Optional[web.TCPSite] = None
         self._legacy_public_site: Optional[web.TCPSite] = None
+        self._theme: str
 
         # slug → Path  (populated from disk on start + runtime additions)
         self._clips: dict[str, Path] = {}
@@ -450,8 +451,10 @@ class ShareServer:
             thumb_url=f"{base}/t/{slug}",
             width=meta.get("width", 1920),
             height=meta.get("height", 1080),
-            theme=_THEMES[self.cfg.share.theme_color]
+            theme=_THEMES[self._theme]
         )
+        
+        
         return web.Response(text=html, content_type="text/html")
 
     async def _video(self, req: web.Request) -> web.Response:

--- a/vice/ui/index.html
+++ b/vice/ui/index.html
@@ -2191,6 +2191,7 @@ async function saveSettings() {
     sharing: {
       port:              +document.getElementById('s-port').value,
       cloudflare_tunnel: document.getElementById('s-cf').checked,
+      theme_color: localStorage.getItem('vice-theme') || 'blue'
     },
   };
   try {


### PR DESCRIPTION
Added embed meta data to support theme-color, when sharing clips the embed color will be based on the vice color theme. 

- Default color is Vice Blue.
- Vice restart is required for the color changes to apply to embeds. 

Closes #38 
