### PR TITLE
fix(ui): resolve unreadable dropdown menus on Wayland/Plasma

### DIFF
--- a/vice/ui/index.html
+++ b/vice/ui/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+<meta name="color-scheme" content="dark">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Vice</title>
 <link rel="stylesheet" href="/styles/base.css?v=__VICE_VERSION__">

--- a/vice/ui/styles/settings.css
+++ b/vice/ui/styles/settings.css
@@ -36,6 +36,7 @@ select:focus, input[type=text]:focus, input[type=number]:focus {
 select { cursor: pointer; padding-right: 32px; appearance: none;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23a6a6a6' stroke-width='2'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
   background-repeat: no-repeat; background-position: right 10px center; }
+option { color: MenuText !important; background-color: Menu !important; }
 input[type=text] { width: 240px; }
 input[type=number] { width: 100px; }
 


### PR DESCRIPTION
Fixes #85 for unreadable white on white dropdown menus on wayland plasma 6, The change to index.html is not nessicary and provides a black background for the dropdown menu which looks nice for your setup dark ui. 

The change to settings .css is the real fix 

Feel free to change just wanted to fix this as was an annoyance on my end and shouldnt change other systems UI if there behaving correctly already but do test

Very well done on the rest of the software I use it alot

Have a great day :) 