### PR TITLE
Fix clip pipeline: fragmented MP4 probing, safe remux, GSR resolution, trim timestamps

### DIFF
--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -1,0 +1,154 @@
+import asyncio
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from vice.media import cleanup_temp_files, get_duration, probe_media
+
+FFMPEG = shutil.which("ffmpeg")
+FFPROBE = shutil.which("ffprobe")
+
+
+def _make_video(path: Path, *, fragmented: bool, duration: float = 1.0) -> None:
+    cmd = [
+        FFMPEG, "-hide_banner", "-loglevel", "error",
+        "-f", "lavfi", "-i", f"testsrc=duration={duration}:size=128x72:rate=10",
+    ]
+    if fragmented:
+        # Fragmented MP4 has no per-stream duration tags — this is what
+        # gpu-screen-recorder writes for replay clips.
+        cmd += ["-movflags", "frag_keyframe+empty_moov"]
+    cmd += ["-y", str(path)]
+    subprocess.run(cmd, check=True, timeout=60)
+
+
+@unittest.skipUnless(FFMPEG and FFPROBE, "ffmpeg/ffprobe not installed")
+class ProbeMediaTests(unittest.IsolatedAsyncioTestCase):
+    async def test_probe_reads_duration_of_regular_mp4(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            clip = Path(tmp) / "clip.mp4"
+            _make_video(clip, fragmented=False)
+            meta = await probe_media(clip)
+
+        self.assertIsNotNone(meta)
+        self.assertEqual(meta["width"], 128)
+        self.assertEqual(meta["height"], 72)
+        self.assertGreater(meta["duration"], 0.5)
+
+    async def test_probe_reads_duration_of_fragmented_mp4(self) -> None:
+        """Regression test for #81: fragmented MP4 has no stream duration
+        tag, and probing only the stream field reported 0 for healthy
+        clips — triggering bogus timeouts and a destructive remux."""
+        with tempfile.TemporaryDirectory() as tmp:
+            clip = Path(tmp) / "clip.mp4"
+            _make_video(clip, fragmented=True)
+            meta = await probe_media(clip)
+            duration = await get_duration(clip)
+
+        self.assertIsNotNone(meta)
+        self.assertGreater(meta["duration"], 0.5)
+        self.assertGreater(duration, 0.5)
+
+    async def test_probe_returns_none_for_garbage(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            junk = Path(tmp) / "junk.mp4"
+            junk.write_bytes(b"this is not a video")
+            meta = await probe_media(junk)
+
+        self.assertIsNone(meta)
+
+
+class CleanupTempFilesTests(unittest.TestCase):
+    def test_removes_edit_leftovers_and_keeps_clips(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            keep = out / "Vice_Clip_1.mp4"
+            keep.write_bytes(b"clip")
+            stale = [
+                out / "Vice_Clip_1.trim.mp4",
+                out / "Vice_Clip_2.wm.mp4",
+                out / "Replay_x.mp4.fix.mp4",
+            ]
+            for p in stale:
+                p.write_bytes(b"partial")
+
+            cleanup_temp_files(out)
+
+            self.assertTrue(keep.exists())
+            for p in stale:
+                self.assertFalse(p.exists(), p.name)
+
+    def test_missing_directory_is_a_noop(self) -> None:
+        cleanup_temp_files(Path("/nonexistent/vice-test-dir"))
+
+
+class RemuxGuardTests(unittest.IsolatedAsyncioTestCase):
+    """_remux_moov must never replace a clip with a worse file."""
+
+    async def test_remux_keeps_original_when_output_is_truncated(self) -> None:
+        from vice.share import _remux_moov
+
+        with tempfile.TemporaryDirectory() as tmp:
+            original = Path(tmp) / "clip.mp4"
+            original.write_bytes(b"x" * 10_000)
+
+            class _Proc:
+                returncode = 0
+
+                async def wait(self):
+                    return 0
+
+            async def _fake_exec(*cmd, **_kwargs):
+                # ffmpeg "succeeds" but emits a near-empty file, like the
+                # 0.02 s remuxes reported in #81.
+                Path(cmd[-1]).write_bytes(b"tiny")
+                return _Proc()
+
+            async def _fake_probe(_: Path):
+                return {"width": 128, "height": 72, "duration": 0.02}
+
+            with mock.patch(
+                "vice.share.asyncio.create_subprocess_exec", new=_fake_exec
+            ):
+                with mock.patch("vice.share.probe_media", new=_fake_probe):
+                    replaced = await _remux_moov(original)
+
+            self.assertFalse(replaced)
+            self.assertEqual(original.read_bytes(), b"x" * 10_000)
+            self.assertEqual(list(Path(tmp).glob("*.fix.mp4")), [])
+
+    async def test_remux_replaces_original_when_output_is_sane(self) -> None:
+        from vice.share import _remux_moov
+
+        with tempfile.TemporaryDirectory() as tmp:
+            original = Path(tmp) / "clip.mp4"
+            original.write_bytes(b"x" * 10_000)
+
+            class _Proc:
+                returncode = 0
+
+                async def wait(self):
+                    return 0
+
+            async def _fake_exec(*cmd, **_kwargs):
+                Path(cmd[-1]).write_bytes(b"y" * 9_800)
+                return _Proc()
+
+            async def _fake_probe(_: Path):
+                return {"width": 128, "height": 72, "duration": 14.9}
+
+            with mock.patch(
+                "vice.share.asyncio.create_subprocess_exec", new=_fake_exec
+            ):
+                with mock.patch("vice.share.probe_media", new=_fake_probe):
+                    replaced = await _remux_moov(original)
+
+            self.assertTrue(replaced)
+            self.assertEqual(original.read_bytes(), b"y" * 9_800)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runtime_and_recorder.py
+++ b/tests/test_runtime_and_recorder.py
@@ -584,7 +584,8 @@ class RecorderStabilizationTests(unittest.IsolatedAsyncioTestCase):
                     clip,
                     stable_polls=3,
                     poll_interval=0.03,
-                    timeout=1.0,
+                    inactivity_timeout=1.0,
+                    max_wait=5.0,
                 )
             elapsed = time.monotonic() - start
             await writer
@@ -592,6 +593,93 @@ class RecorderStabilizationTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(ready)
         self.assertGreaterEqual(elapsed, 0.18)
         self.assertEqual(observed[-1], b"abc")
+
+    async def test_wait_for_finalized_clip_gives_up_after_write_inactivity(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            clip = Path(tmp) / "raw.mp4"
+            clip.write_bytes(b"not a video")
+
+            async def _zero_duration(_: Path) -> float:
+                return 0.0
+
+            start = time.monotonic()
+            with mock.patch("vice.recorder._get_duration", new=_zero_duration):
+                ready = await _wait_for_finalized_clip(
+                    clip,
+                    stable_polls=2,
+                    poll_interval=0.02,
+                    inactivity_timeout=0.15,
+                    max_wait=5.0,
+                )
+            elapsed = time.monotonic() - start
+
+        self.assertFalse(ready)
+        self.assertLess(elapsed, 2.0)
+
+    async def test_wait_for_finalized_clip_tolerates_slow_writes(self) -> None:
+        """A file that keeps growing must not be abandoned, even when the
+        total write time exceeds the inactivity timeout."""
+        with tempfile.TemporaryDirectory() as tmp:
+            clip = Path(tmp) / "raw.mp4"
+
+            async def _writer() -> None:
+                # Total write time (0.8 s) far exceeds the inactivity
+                # timeout (0.3 s); only the gaps between writes count.
+                data = b""
+                for _ in range(16):
+                    data += b"x" * 10
+                    clip.write_bytes(data)
+                    await asyncio.sleep(0.05)
+
+            durations = iter([0.0] * 2)
+
+            async def _fake_duration(_: Path) -> float:
+                return next(durations, 30.0)
+
+            writer = asyncio.create_task(_writer())
+            with mock.patch("vice.recorder._get_duration", new=_fake_duration):
+                ready = await _wait_for_finalized_clip(
+                    clip,
+                    stable_polls=2,
+                    poll_interval=0.03,
+                    inactivity_timeout=0.3,
+                    max_wait=5.0,
+                )
+            await writer
+
+        self.assertTrue(ready)
+
+    async def test_trim_copy_command_avoids_negative_timestamps(self) -> None:
+        captured: dict = {}
+
+        async def _fake_duration(_: Path) -> float:
+            return 100.0
+
+        class _Proc:
+            returncode = 0
+
+            async def communicate(self):
+                return b"", b""
+
+        async def _fake_exec(*cmd, **_kwargs):
+            captured["cmd"] = list(cmd)
+            return _Proc()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            clip = Path(tmp) / "clip.mp4"
+            clip.write_bytes(b"clip")
+            with mock.patch("vice.recorder._get_duration", new=_fake_duration):
+                with mock.patch(
+                    "vice.recorder.asyncio.create_subprocess_exec", new=_fake_exec
+                ):
+                    from vice.recorder import _trim_to_last_n_seconds
+
+                    await _trim_to_last_n_seconds(clip, 30)
+
+        cmd = captured["cmd"]
+        self.assertIn("-avoid_negative_ts", cmd)
+        self.assertEqual(cmd[cmd.index("-avoid_negative_ts") + 1], "make_zero")
+        self.assertIn("copy", cmd)
 
     async def test_gsr_save_clip_waits_for_finalized_file_before_trim(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -728,6 +816,53 @@ class RecorderAudioCommandTests(unittest.TestCase):
         cmd = recorder._build_cmd()
 
         self.assertEqual(cmd[cmd.index("-a") + 1], "device:game.monitor|default_input")
+
+    def test_gsr_build_cmd_passes_configured_resolution(self) -> None:
+        recorder = GSRRecorder(
+            Config(
+                output=OutputConfig(directory="/tmp/vice-test"),
+                recording=RecordingConfig(resolution="1280x720"),
+            )
+        )
+
+        cmd = recorder._build_cmd()
+
+        self.assertEqual(cmd[cmd.index("-s") + 1], "1280x720")
+
+    def test_gsr_build_cmd_ignores_invalid_resolution(self) -> None:
+        recorder = GSRRecorder(
+            Config(
+                output=OutputConfig(directory="/tmp/vice-test"),
+                recording=RecordingConfig(resolution="720p"),
+            )
+        )
+
+        cmd = recorder._build_cmd()
+
+        self.assertNotIn("-s", cmd)
+
+    def test_gsr_build_cmd_keeps_user_resolution_override(self) -> None:
+        recorder = GSRRecorder(
+            Config(
+                output=OutputConfig(directory="/tmp/vice-test"),
+                recording=RecordingConfig(
+                    resolution="1280x720",
+                    gsr_args="-s 640x360",
+                ),
+            )
+        )
+
+        cmd = recorder._build_cmd()
+
+        self.assertEqual(cmd.count("-s"), 1)
+        self.assertEqual(cmd[cmd.index("-s") + 1], "640x360")
+
+    def test_gsr_session_cmd_passes_configured_resolution(self) -> None:
+        rc = RecordingConfig(resolution="1920x1080")
+
+        cmd = GSRRecorder._gsr_session_cmd(Path("/tmp/vice-test/out.mp4"), rc)
+
+        self.assertEqual(cmd[cmd.index("-s") + 1], "1920x1080")
 
     def test_gsr_build_cmd_maps_hevc_encoder_to_gsr_codec(self) -> None:
         recorder = GSRRecorder(

--- a/vice/main.py
+++ b/vice/main.py
@@ -44,6 +44,7 @@ from .config import (
     save as save_config,
 )
 from .hotkey import HotkeyListener, can_access_hotkeys, list_available_keys
+from .media import cleanup_temp_files
 from .recorder import create_recorder
 from .runtime import (
     actual_home_dir,
@@ -126,7 +127,11 @@ class ViceDaemon:
 
     async def run(self) -> None:
         Path("/tmp/vice").mkdir(parents=True, exist_ok=True)
-        resolve_path(self.cfg.output.directory).mkdir(parents=True, exist_ok=True)
+        out_dir = resolve_path(self.cfg.output.directory)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        # Remove half-written temp files (trim/watermark/remux) from a
+        # previous run that was interrupted mid-edit.
+        cleanup_temp_files(out_dir)
 
         # Share server (web UI + REST API + WebSocket)
         if self.cfg.sharing.enabled:

--- a/vice/media.py
+++ b/vice/media.py
@@ -1,0 +1,93 @@
+"""Shared ffprobe helpers for clip files.
+
+Used by both the recorder (clip finalization, trimming) and the share
+server (metadata, thumbnails). Kept in one place so duration handling
+behaves identically everywhere.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import math
+from pathlib import Path
+from typing import Optional
+
+log = logging.getLogger("vice.media")
+
+# Suffix patterns for temp files written during in-place edits
+# (trim / watermark / remux). Leftovers mean a previous run was
+# interrupted mid-edit; they are safe to delete at daemon startup.
+TEMP_FILE_GLOBS = ("*.trim.mp4", "*.wm.mp4", "*.fix.mp4")
+
+
+async def probe_media(path: Path) -> Optional[dict]:
+    """Probe *path* with ffprobe.
+
+    Returns ``{"width", "height", "duration"}`` or ``None`` when ffprobe
+    fails or the file has no video stream.
+
+    Duration prefers the container (format) value over the stream value:
+    fragmented MP4 — which gpu-screen-recorder writes for replay clips —
+    has no per-stream duration tag, so reading only the stream field
+    reports 0 for perfectly healthy files.
+    """
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "ffprobe", "-v", "quiet", "-print_format", "json",
+            "-show_format", "-show_streams", str(path),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=15)
+        data = json.loads(stdout)
+    except FileNotFoundError:
+        log.error("ffprobe not found — install ffmpeg to read clip metadata")
+        return None
+    except Exception as exc:
+        log.debug("ffprobe failed for %s: %s", path.name, exc)
+        return None
+
+    video = next(
+        (s for s in data.get("streams", []) if s.get("codec_type") == "video"),
+        None,
+    )
+    if video is None:
+        return None
+
+    duration = _parse_duration(data.get("format", {}).get("duration"))
+    if duration <= 0:
+        duration = _parse_duration(video.get("duration"))
+    return {
+        "width": int(video.get("width") or 0),
+        "height": int(video.get("height") or 0),
+        "duration": duration,
+    }
+
+
+def _parse_duration(raw) -> float:
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return 0.0
+    return value if math.isfinite(value) and value > 0 else 0.0
+
+
+async def get_duration(path: Path) -> float:
+    """Duration of *path* in seconds, or 0.0 when it cannot be read."""
+    meta = await probe_media(path)
+    return meta["duration"] if meta else 0.0
+
+
+def cleanup_temp_files(directory: Path) -> None:
+    """Delete leftover in-place-edit temp files from interrupted runs."""
+    if not directory.is_dir():
+        return
+    for pattern in TEMP_FILE_GLOBS:
+        for stale in directory.glob(pattern):
+            try:
+                stale.unlink()
+                log.info("Removed stale temp file %s", stale.name)
+            except OSError as exc:
+                log.warning("Could not remove stale temp file %s: %s", stale, exc)

--- a/vice/recorder.py
+++ b/vice/recorder.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from typing import Callable, List, Optional
 
 from .config import Config
+from .media import get_duration as _get_duration
 from .runtime import recover_wayland_display, resolve_path
 
 log = logging.getLogger("vice.recorder")
@@ -191,6 +192,20 @@ def _gsr_codec_for_encoder(encoder: str) -> Optional[str]:
     if encoder in {"hevc_nvenc", "hevc_vaapi", "libx265"}:
         return "hevc"
     return None
+
+
+def _gsr_resolution_args(rc, extra: list[str]) -> list[str]:
+    """GSR `-s WxH` flag for the configured output resolution, if any."""
+    resolution = (getattr(rc, "resolution", None) or "").strip()
+    if not resolution or _gsr_has_any_flag(extra, "-s"):
+        return []
+    if not re.fullmatch(r"\d+x\d+", resolution):
+        log.warning(
+            "Ignoring recording.resolution=%r — expected WIDTHxHEIGHT (e.g. 1920x1080)",
+            resolution,
+        )
+        return []
+    return ["-s", resolution]
 
 
 def _gsr_sanitize_args(args: list[str], blocked_flags: set[str]) -> list[str]:
@@ -975,6 +990,7 @@ class Recorder(ABC):
             cmd += ["-w", _gsr_capture_target(rc)]
         if not _gsr_has_any_flag(extra, "-f"):
             cmd += ["-f", str(rc.fps)]
+        cmd += _gsr_resolution_args(rc, extra)
         if not _gsr_has_any_flag(extra, "-c"):
             cmd += ["-c", "mp4"]
         codec = _gsr_codec_for_encoder(rc.encoder)
@@ -1028,23 +1044,6 @@ def _next_session_path(out_dir: Path) -> Path:
     return out_dir / f"Vice_Session_{max_n + 1}.mp4"
 
 
-async def _get_duration(path: Path) -> float:
-    """Return the duration of a video file in seconds via ffprobe."""
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            "ffprobe", "-v", "quiet", "-print_format", "json", "-show_streams", str(path),
-            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.DEVNULL,
-        )
-        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=15)
-        import json
-        for s in json.loads(stdout).get("streams", []):
-            if s.get("codec_type") == "video":
-                return float(s.get("duration", 0))
-    except Exception:
-        pass
-    return 0.0
-
-
 async def _trim_to_last_n_seconds(path: Path, seconds: int) -> Path:
     """Trim a clip to its last `seconds` seconds in-place. Returns the path."""
     total = await _get_duration(path)
@@ -1057,7 +1056,9 @@ async def _trim_to_last_n_seconds(path: Path, seconds: int) -> Path:
         return [
             "ffmpeg", "-hide_banner", "-loglevel", "error",
             "-ss", str(start), "-i", str(path),
-            "-t", str(seconds), "-c", "copy", "-movflags", "+faststart",
+            "-t", str(seconds), "-c", "copy",
+            "-avoid_negative_ts", "make_zero",
+            "-movflags", "+faststart",
             "-y", str(tmp),
         ]
 
@@ -1107,11 +1108,21 @@ async def _wait_for_finalized_clip(
     *,
     stable_polls: int = 3,
     poll_interval: float = 0.25,
-    timeout: float = 10.0,
+    inactivity_timeout: float = 15.0,
+    max_wait: float = 600.0,
 ) -> bool:
-    """Wait until a replay clip stops changing and ffprobe can read it."""
-    deadline = time.monotonic() + timeout
+    """Wait until a replay clip stops changing and ffprobe can read it.
+
+    The timeout is based on write inactivity, not total elapsed time:
+    flushing a long replay buffer can legitimately take minutes on slow
+    storage, and a fixed deadline used to abandon clips that were still
+    being written (and would have finished fine). We only give up when
+    the file has stopped growing for `inactivity_timeout` seconds and
+    still cannot be probed, or after `max_wait` as a hard safety cap.
+    """
+    deadline = time.monotonic() + max_wait
     last_sig: tuple[int, int] | None = None
+    last_change = time.monotonic()
     stable = 0
 
     while time.monotonic() < deadline:
@@ -1119,17 +1130,22 @@ async def _wait_for_finalized_clip(
             st = path.stat()
             sig = (st.st_size, st.st_mtime_ns)
         except OSError:
-            await asyncio.sleep(poll_interval)
-            continue
+            sig = None
 
-        if sig[0] > 0 and sig == last_sig:
+        if sig != last_sig:
+            stable = 0
+            last_sig = sig
+            last_change = time.monotonic()
+        elif sig is not None and sig[0] > 0:
             stable += 1
         else:
             stable = 0
-            last_sig = sig
 
         if stable >= stable_polls and await _get_duration(path) > 0:
             return True
+
+        if time.monotonic() - last_change > inactivity_timeout:
+            return False
 
         await asyncio.sleep(poll_interval)
 
@@ -1209,6 +1225,8 @@ class GSRRecorder(Recorder):
 
         if not _gsr_has_any_flag(extra, "-f"):
             cmd += ["-f", str(rc.fps)]
+
+        cmd += _gsr_resolution_args(rc, extra)
 
         if not _gsr_has_any_flag(extra, "-r"):
             cmd += ["-r", str(rc.buffer_duration)]
@@ -1298,7 +1316,8 @@ class GSRRecorder(Recorder):
             log.error("GSR process not found")
             return None
 
-        # Wait for the new file to appear and finish writing.
+        # Wait for the new file to appear (GSR creates it almost immediately
+        # after SIGUSR1), then wait for GSR to finish writing it.
         deadline = time.monotonic() + 20
         while time.monotonic() < deadline:
             await asyncio.sleep(0.25)
@@ -1310,9 +1329,12 @@ class GSRRecorder(Recorder):
                     key=lambda p: p.stat().st_mtime,
                 )
                 self._seen_files = current
-                remaining = max(0.5, deadline - time.monotonic())
-                if not await _wait_for_finalized_clip(newest, timeout=remaining):
-                    log.error("Timed out waiting for GSR clip to finish writing: %s", newest)
+                if not await _wait_for_finalized_clip(newest):
+                    log.error(
+                        "GSR clip %s stopped being written but is unreadable — "
+                        "leaving the file in place for inspection",
+                        newest,
+                    )
                     return None
                 # Rename GSR's auto-generated filename to sequential Vice_Clip_N name.
                 seq_path = _next_clip_path(self._out_dir)

--- a/vice/share.py
+++ b/vice/share.py
@@ -16,7 +16,6 @@ import asyncio
 import copy
 import json
 import logging
-import math
 import shutil
 import socket
 import subprocess
@@ -30,6 +29,7 @@ from importlib.resources import files as _pkg_files
 from aiohttp import WSMsgType, web
 
 from . import __version__
+from .media import probe_media
 from .recorder import list_display_options, list_gsr_audio_sources
 from .runtime import actual_home_dir, resolve_path
 
@@ -140,35 +140,19 @@ def _local_ip() -> str:
         return "127.0.0.1"
 
 
-async def _probe_once(path: Path) -> dict:
-    """Run a single ffprobe pass. Returns sensible defaults on failure."""
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            "ffprobe", "-v", "quiet", "-print_format", "json",
-            "-show_streams", str(path),
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.DEVNULL,
-        )
-        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=15)
-        data = json.loads(stdout)
-        for s in data.get("streams", []):
-            if s.get("codec_type") == "video":
-                return {
-                    "width":    s.get("width",    1920),
-                    "height":   s.get("height",   1080),
-                    "duration": float(s.get("duration", 0)),
-                }
-    except Exception:
-        pass
-    return {"width": 1920, "height": 1080, "duration": 0}
+_PROBE_DEFAULTS = {"width": 1920, "height": 1080, "duration": 0}
 
 
 async def _remux_moov(path: Path) -> bool:
-    """Rewrite `path` via `ffmpeg -c copy -movflags +faststart` in place.
+    """Try to recover `path` via `ffmpeg -c copy -movflags +faststart`.
 
-    Used to recover clips whose MP4 container is missing/corrupt (no moov
-    atom) — happens when the encoder was killed mid-finalize. Returns True
-    when the remuxed file successfully replaced the original.
+    Used for clips whose MP4 container is damaged (no moov atom) — happens
+    when the encoder was killed mid-finalize. The original file is only
+    replaced when the remuxed copy probes as a sane video of comparable
+    size; a remux that produces a near-empty file means the input was
+    *not* a simple moov-atom problem, and replacing would destroy data
+    (this used to truncate healthy clips to 0.02 s). Returns True when
+    the remuxed file replaced the original.
     """
     tmp = path.with_suffix(path.suffix + ".fix.mp4")
     try:
@@ -180,11 +164,26 @@ async def _remux_moov(path: Path) -> bool:
             stderr=asyncio.subprocess.DEVNULL,
         )
         await asyncio.wait_for(proc.wait(), timeout=60)
-        if proc.returncode == 0 and tmp.exists() and tmp.stat().st_size > 0:
-            tmp.replace(path)
-            return True
-    except Exception:
-        pass
+        if proc.returncode == 0 and tmp.exists():
+            remuxed = await probe_media(tmp)
+            orig_size = path.stat().st_size
+            if (
+                remuxed
+                and remuxed["duration"] > 0
+                and tmp.stat().st_size >= orig_size * 0.5
+            ):
+                tmp.replace(path)
+                return True
+            log.warning(
+                "Remux of %s produced an invalid or truncated file "
+                "(duration=%.2fs, %d → %d bytes) — keeping the original",
+                path.name,
+                remuxed["duration"] if remuxed else 0.0,
+                orig_size,
+                tmp.stat().st_size,
+            )
+    except Exception as exc:
+        log.warning("Remux of %s failed: %s", path.name, exc)
     try:
         tmp.unlink(missing_ok=True)
     except Exception:
@@ -195,19 +194,21 @@ async def _remux_moov(path: Path) -> bool:
 async def _ffprobe(path: Path) -> dict:
     """Return {"width", "height", "duration"} via ffprobe.
 
-    If the first probe yields a zero / non-finite duration the container
-    is probably missing its moov atom — try one remux + re-probe before
-    giving up.
+    If the file cannot be probed at all, its container is probably missing
+    the moov atom — try one (validated, non-destructive) remux + re-probe
+    before giving up.
     """
-    meta = await _probe_once(path)
-    dur = meta.get("duration", 0)
-    if isinstance(dur, (int, float)) and math.isfinite(dur) and dur > 0:
+    meta = await probe_media(path)
+    if meta and meta["duration"] > 0:
         return meta
-    log.warning("ffprobe reports duration=%s for %s — attempting moov remux", dur, path.name)
+    log.warning("ffprobe cannot read %s — attempting moov remux", path.name)
     if await _remux_moov(path):
-        meta = await _probe_once(path)
-        log.info("Remuxed %s — duration now %.2fs", path.name, meta.get("duration", 0))
-    return meta
+        meta = await probe_media(path)
+        log.info(
+            "Remuxed %s — duration now %.2fs",
+            path.name, meta["duration"] if meta else 0.0,
+        )
+    return meta or dict(_PROBE_DEFAULTS)
 
 
 async def _make_thumb(path: Path, duration: float = 0.0) -> Path:


### PR DESCRIPTION
## Root cause

The duration probe in both `recorder.py` and `share.py` read only the per-stream `duration` tag from ffprobe. Fragmented MP4 — which gpu-screen-recorder writes for replay clips — has no per-stream duration tags, so healthy clips probed as `duration=0`. That one bug produced two user-visible failures:

1. `save_clip` hit "Timed out waiting for GSR clip to finish writing" on clips that were perfectly fine, then abandoned them (never renamed/emitted, so they never appeared in Vice).
2. On the next startup, the share server saw `duration=0`, assumed a missing moov atom, and ran an **in-place remux that replaced the playable file with a 0.02 s husk**. This is the corruption described in #81.

## Changes

- **New `vice/media.py`** — single shared ffprobe helper (`probe_media` / `get_duration`) used by recorder and share server. Reads the container (format) duration first, stream duration as fallback. Replaces two diverging copies of the same logic.
- **Remux is now guarded** — `_remux_moov` only replaces the original when the remuxed copy probes as a sane video of comparable size (≥50% of the original bytes, duration > 0). A remux that produces a near-empty file leaves the original untouched and logs why. Genuinely corrupt clips are kept for inspection instead of being silently shredded.
- **Finalization wait is inactivity-based** — `_wait_for_finalized_clip` used a fixed 20 s total deadline; flushing a long replay buffer on slow storage can legitimately take longer. It now only gives up after the file stops growing for 15 s and still can't be probed (10 min hard cap).
- **GSR gets `-s WxH`** — the resolution setting was silently ignored on the default backend; clips always came out at native resolution (#80). Applied to both replay and session commands, with validation and a user-override guard (`gsr_args -s` wins).
- **Copy trims pass `-avoid_negative_ts make_zero`** — clips cut mid-GOP keep audio/video aligned (#73).
- **Startup cleanup** — leftover `.trim.mp4`/`.wm.mp4`/`.fix.mp4` temp files from interrupted edits are deleted when the daemon starts (they previously showed up as broken clips in the gallery).

## Verification

- `python -m unittest discover tests/` — 105 tests pass (14 new).
- New tests generate a real fragmented MP4 with ffmpeg and assert the probe reads its duration (regression test for #81), assert the remux guard rejects truncated output, and cover the `-s` flag, override precedence, inactivity timeout, and slow-write tolerance.
- Reasoned but not hardware-tested: GSR's `-s` flag exists in the pinned 5.13.3 and the 5.12.5 FFmpeg-6 fallback; if an older GSR lacks it, the daemon's existing startup stderr capture reports the unknown flag clearly.
- For #73 (audio desync) the trim fix plus the resolution fix address the most likely causes; asking the reporter to confirm on Fedora is recommended before closing it manually if it doesn't auto-close.

Closes #81, closes #80, closes #73.

🤖 Generated with [Claude Code](https://claude.com/claude-code)