### PR TITLE
Harden desktop app and UI: webview stability, clipboard fallback, animation leak, dropdown contrast

### DIFF
--- a/tests/test_runtime_and_recorder.py
+++ b/tests/test_runtime_and_recorder.py
@@ -150,6 +150,52 @@ class RuntimeEnvironmentTests(unittest.TestCase):
         debug_mock.assert_any_call("Runtime env after normalization: %s", mock.ANY)
 
 
+class WebviewEnvironmentTests(unittest.TestCase):
+    def test_sets_default_chromium_flags(self) -> None:
+        env = {"LANG": "en_US.UTF-8"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            with mock.patch("vice.app._is_nvidia", return_value=False):
+                app_mod._prepare_webview_environment()
+            flags = os.environ["QTWEBENGINE_CHROMIUM_FLAGS"]
+
+        self.assertIn("--disable-accelerated-video-decode", flags)
+        self.assertNotIn("Vulkan", flags)
+
+    def test_nvidia_disables_vulkan_fallback(self) -> None:
+        with mock.patch.dict(os.environ, {"LANG": "en_US.UTF-8"}, clear=True):
+            with mock.patch("vice.app._is_nvidia", return_value=True):
+                app_mod._prepare_webview_environment()
+            flags = os.environ["QTWEBENGINE_CHROMIUM_FLAGS"]
+
+        self.assertIn("--disable-features=Vulkan", flags)
+
+    def test_user_flags_are_respected(self) -> None:
+        env = {"LANG": "en_US.UTF-8", "QTWEBENGINE_CHROMIUM_FLAGS": "--my-flag"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            app_mod._prepare_webview_environment()
+            self.assertEqual(os.environ["QTWEBENGINE_CHROMIUM_FLAGS"], "--my-flag")
+
+    def test_extra_flags_are_appended(self) -> None:
+        env = {"LANG": "en_US.UTF-8", "VICE_WEBVIEW_FLAGS": "--extra-flag"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            with mock.patch("vice.app._is_nvidia", return_value=False):
+                app_mod._prepare_webview_environment()
+            self.assertIn("--extra-flag", os.environ["QTWEBENGINE_CHROMIUM_FLAGS"])
+
+    def test_c_locale_is_replaced_with_utf8(self) -> None:
+        # Qt switches away from a C locale with loud warnings; systemd
+        # user services often start without any locale at all (#82).
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with mock.patch("vice.app._is_nvidia", return_value=False):
+                app_mod._prepare_webview_environment()
+            self.assertEqual(os.environ["LC_ALL"], "C.UTF-8")
+
+        with mock.patch.dict(os.environ, {"LANG": "de_DE.UTF-8"}, clear=True):
+            with mock.patch("vice.app._is_nvidia", return_value=False):
+                app_mod._prepare_webview_environment()
+            self.assertNotIn("LC_ALL", os.environ)
+
+
 class AppStartupTests(unittest.TestCase):
     def test_start_daemon_passes_normalized_environment_to_child(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_ui_static.py
+++ b/tests/test_ui_static.py
@@ -5,6 +5,8 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 UI_INDEX = REPO_ROOT / "vice" / "ui" / "index.html"
 HOME_JS = REPO_ROOT / "vice" / "ui" / "scripts" / "home.js"
+SETTINGS_CSS = REPO_ROOT / "vice" / "ui" / "styles" / "settings.css"
+HOME_CSS = REPO_ROOT / "vice" / "ui" / "styles" / "home.css"
 README = REPO_ROOT / "README.md"
 
 
@@ -30,6 +32,24 @@ class UIStaticCopyTests(unittest.TestCase):
 
         self.assertIn("On by default", copy)
         self.assertNotIn("off by default", copy.lower())
+
+    def test_dark_color_scheme_declared_for_native_dropdowns(self) -> None:
+        # Without these, native <select> popups render white-on-white on
+        # KDE Plasma 6 / Wayland (#85).
+        self.assertIn('<meta name="color-scheme" content="dark">', self.index)
+        css = SETTINGS_CSS.read_text()
+        self.assertIn("select option", css)
+        self.assertIn("MenuText", css)
+
+    def test_manual_copy_modal_exists(self) -> None:
+        self.assertIn('id="manual-copy-modal"', self.index)
+        self.assertIn('id="manual-copy-text"', self.index)
+
+    def test_buffer_viz_uses_css_animation_not_js_timer(self) -> None:
+        # A perpetual JS style-mutation loop leaked renderer memory while
+        # the window sat open (#83); the bars must animate via CSS.
+        self.assertNotIn("setInterval", self.home_js)
+        self.assertIn("buffer-pulse", HOME_CSS.read_text())
 
 
 if __name__ == "__main__":

--- a/vice/app.py
+++ b/vice/app.py
@@ -472,6 +472,55 @@ def _show_error(message: str) -> None:
 
 # ── pywebview window ──────────────────────────────────────────────────────────
 
+def _is_nvidia() -> bool:
+    return Path("/proc/driver/nvidia/version").exists()
+
+
+def _prepare_webview_environment() -> None:
+    """Set environment for a stable QtWebEngine (Chromium) session.
+
+    Must run before QtWebEngine initialises — Chromium reads
+    QTWEBENGINE_CHROMIUM_FLAGS once at startup.
+
+    Why each flag is needed:
+      • --disable-accelerated-video-decode / --disable-gpu-memory-buffer-
+        video-frames: Chromium's hardware video decode is broken on many
+        Linux GPU/driver combos and renders <video> as a black or grey
+        rectangle while the rest of the UI works. Clips are short, local
+        files; software decode is cheap and always correct.
+      • --autoplay-policy: clip previews start without a click.
+      • --disable-features=Vulkan (NVIDIA only): when GBM is unavailable
+        Chromium falls back to Vulkan rendering, which segfaults on
+        NVIDIA driver setups without GBM support. Disabling Vulkan makes
+        it fall back to software GL instead of crashing.
+
+    Users can replace all of this by setting QTWEBENGINE_CHROMIUM_FLAGS
+    themselves, or append extra flags via VICE_WEBVIEW_FLAGS.
+    """
+    # Qt requires a UTF-8 locale; a "C"/POSIX locale makes it switch with
+    # loud warnings and has preceded renderer crashes (systemd services
+    # often start with no locale at all).
+    locale_value = os.environ.get("LC_ALL") or os.environ.get("LANG") or ""
+    if locale_value in ("", "C", "POSIX"):
+        os.environ["LC_ALL"] = "C.UTF-8"
+        os.environ["LANG"] = "C.UTF-8"
+
+    if "QTWEBENGINE_CHROMIUM_FLAGS" in os.environ:
+        return  # user override — leave it alone
+    flags = [
+        "--disable-accelerated-video-decode",
+        "--disable-gpu-memory-buffer-video-frames",
+        "--autoplay-policy=no-user-gesture-required",
+    ]
+    if _is_nvidia():
+        flags.append("--disable-features=Vulkan")
+    extra = os.environ.get("VICE_WEBVIEW_FLAGS", "").strip()
+    if extra:
+        flags.append(extra)
+    os.environ["QTWEBENGINE_CHROMIUM_FLAGS"] = " ".join(flags)
+    log.info("QTWEBENGINE_CHROMIUM_FLAGS=%s", os.environ["QTWEBENGINE_CHROMIUM_FLAGS"])
+
+
 def _patch_pywebview_qt_permissions() -> None:
     """Work around pywebview 6.x + PyQt6 6.11 enum-vs-int incompatibility.
 
@@ -502,6 +551,7 @@ def _patch_pywebview_qt_permissions() -> None:
 
 
 def _run_webview(url: str) -> None:
+    _prepare_webview_environment()
     import webview  # type: ignore[import]
 
     class _API:
@@ -607,6 +657,13 @@ def _run_webview(url: str) -> None:
     # on NVIDIA + Wayland entirely. GTK/WebKit2GTK is the fallback.
     # pywebview's Qt backend imports `qtpy` (a Qt-binding shim) plus the
     # PyQt6 QtWebEngine bindings — both must be present.
+    def _enable_gtk_workarounds() -> None:
+        # WebKit2GTK + Wayland + NVIDIA crashes with "Error 71 (Protocol error)".
+        # XWayland is the safe path. These vars are harmless on other setups.
+        os.environ.setdefault("WEBKIT_DISABLE_SANDBOX", "1")
+        os.environ.setdefault("WEBKIT_DISABLE_DMABUF_RENDERER", "1")
+        os.environ.setdefault("GDK_BACKEND", "x11")
+
     try:
         import PyQt6.QtWebEngineWidgets  # noqa: F401 — probe
         import qtpy                      # noqa: F401 — pywebview's Qt shim
@@ -616,11 +673,7 @@ def _run_webview(url: str) -> None:
         log.info("Using QtWebEngine (Chromium) backend")
     except ImportError as exc:
         gui = None  # pywebview's Linux default: GTK/WebKit2GTK
-        # WebKit2GTK + Wayland + NVIDIA crashes with "Error 71 (Protocol error)".
-        # XWayland is the safe path. These vars are harmless on other setups.
-        os.environ.setdefault("WEBKIT_DISABLE_SANDBOX", "1")
-        os.environ.setdefault("WEBKIT_DISABLE_DMABUF_RENDERER", "1")
-        os.environ.setdefault("GDK_BACKEND", "x11")
+        _enable_gtk_workarounds()
         log.info(
             "Qt backend unavailable (%s) — falling back to GTK WebKit on XWayland. "
             "For full GPU acceleration install python-pyqt6-webengine + python-qtpy.",
@@ -631,7 +684,13 @@ def _run_webview(url: str) -> None:
         webview.start(gui=gui, debug=False, private_mode=False)
     except Exception:
         log.exception("webview.start raised — backend=%s", gui)
-        raise
+        if gui != "qt":
+            raise
+        # Qt died before opening a window — retry once on GTK/WebKit2GTK
+        # so the user still gets a native window instead of nothing.
+        log.warning("Retrying with the GTK WebKit backend")
+        _enable_gtk_workarounds()
+        webview.start(gui=None, debug=False, private_mode=False)
     log.info("Window closed")
 
 

--- a/vice/ui/index.html
+++ b/vice/ui/index.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="color-scheme" content="dark">
 <title>Vice</title>
 <link rel="stylesheet" href="/styles/base.css?v=__VICE_VERSION__">
 <link rel="stylesheet" href="/styles/nav.css?v=__VICE_VERSION__">
@@ -673,6 +674,18 @@
 </div>
 
 <!-- ── Restart modal ──────────────────────────────────────────────── -->
+<!-- ── Manual copy fallback modal ─────────────────────────────────── -->
+<div id="manual-copy-modal" class="hidden">
+  <div class="restart-box">
+    <div class="restart-title">Copy manually</div>
+    <div class="restart-sub">Automatic clipboard access is unavailable on this system. Select the text below and press Ctrl-C.</div>
+    <input type="text" id="manual-copy-text" class="mono manual-copy-input" readonly onclick="this.select()">
+    <div class="restart-actions">
+      <button class="btn-pill btn-ghost-pill" onclick="closeManualCopyModal()">Done</button>
+    </div>
+  </div>
+</div>
+
 <div id="restart-modal" class="hidden">
   <div class="restart-box">
     <div class="restart-title">Restart required</div>

--- a/vice/ui/scripts/clips.js
+++ b/vice/ui/scripts/clips.js
@@ -134,8 +134,10 @@ function copyLink(ev, url) {
   if (ev) { ev.preventDefault(); ev.stopPropagation(); }
   nativeLog(`copyLink: url=${(url || '').slice(0, 60)}`);
   if (!url) return;
-  copyToClipboard(url).then(ok =>
-    toast(ok ? 'Share link copied!' : 'Could not copy link', ok ? 'ok' : 'err'));
+  copyToClipboard(url).then(ok => {
+    if (ok) toast('Share link copied!', 'ok');
+    else showManualCopyModal(url);
+  });
 }
 
 async function revealClip(slug) {

--- a/vice/ui/scripts/helpers.js
+++ b/vice/ui/scripts/helpers.js
@@ -96,6 +96,8 @@ window.addEventListener('unhandledrejection', ev => {
 });
 
 function copyUninstallCmd() {
-  copyToClipboard('vice uninstall').then(ok =>
-    toast(ok ? 'Command copied — paste it into a terminal' : 'Could not copy', ok ? 'ok' : 'err'));
+  copyToClipboard('vice uninstall').then(ok => {
+    if (ok) toast('Command copied — paste it into a terminal', 'ok');
+    else showManualCopyModal('vice uninstall');
+  });
 }

--- a/vice/ui/scripts/home.js
+++ b/vice/ui/scripts/home.js
@@ -4,37 +4,35 @@
 // ═══════════════════════════════════════════════════════════════════
 // Home population — uses cfg + runtime status
 // ═══════════════════════════════════════════════════════════════════
-let _bufferVizTimer = null;
+// The bars animate via a pure CSS transform keyframe (see home.css) instead
+// of a JS timer mutating heights: a perpetual 500 ms style-mutation loop kept
+// the renderer compositing forever and leaked GPU/renderer memory while the
+// window sat open (#83). scaleY runs on the compositor and costs ~nothing,
+// and pausing is a single class toggle.
 function populateBufferViz() {
   const viz = document.getElementById('buffer-viz');
-  if (viz.children.length) return;  // already built
+  if (!viz || viz.children.length) return;  // already built
   for (let i = 0; i < 48; i++) {
     const b = document.createElement('div');
     b.className = 'buffer-bar';
-    const h = 14 + Math.sin(i * 0.4) * 20 + Math.random() * 28;
-    b.style.height = Math.max(8, Math.min(60, h)) + 'px';
-    b.style.animationDelay = (i * 20) + 'ms';
+    const base = (34 + Math.sin(i * 0.4) * 20 + Math.random() * 28) / 60;
+    b.style.setProperty('--s1', Math.max(0.13, Math.min(1, base)).toFixed(3));
+    b.style.setProperty('--s2', Math.max(0.13, Math.min(1, base + (Math.random() - 0.5) * 0.6)).toFixed(3));
+    b.style.setProperty('--s3', Math.max(0.13, Math.min(1, base + (Math.random() - 0.5) * 0.6)).toFixed(3));
+    b.style.animationDuration = (2.2 + Math.random() * 1.8).toFixed(2) + 's';
+    b.style.animationDelay = (-Math.random() * 4).toFixed(2) + 's';
     viz.appendChild(b);
   }
-  startBufferViz();
 }
 
 function startBufferViz() {
-  if (_bufferVizTimer) return;
   const viz = document.getElementById('buffer-viz');
-  if (!viz) return;
-  _bufferVizTimer = setInterval(() => {
-    [...viz.children].forEach((b, i) => {
-      const h = 14 + Math.sin((Date.now()/300 + i * 0.4)) * 20 + Math.random() * 20;
-      b.style.height = Math.max(8, Math.min(60, h)) + 'px';
-    });
-  }, 500);
+  if (viz) viz.classList.remove('viz-paused');
 }
 
 function stopBufferViz() {
-  if (!_bufferVizTimer) return;
-  clearInterval(_bufferVizTimer);
-  _bufferVizTimer = null;
+  const viz = document.getElementById('buffer-viz');
+  if (viz) viz.classList.add('viz-paused');
 }
 
 function hotkeyLabel() {

--- a/vice/ui/scripts/init.js
+++ b/vice/ui/scripts/init.js
@@ -74,3 +74,10 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 });
 window.addEventListener('resize', moveNavIndicator);
+
+// Pause the rolling-buffer animation whenever the window is hidden or
+// minimised, so an idle Vice window costs no rendering work at all.
+document.addEventListener('visibilitychange', () => {
+  if (document.hidden) stopBufferViz();
+  else if (currentView === 'home') startBufferViz();
+});

--- a/vice/ui/scripts/modals.js
+++ b/vice/ui/scripts/modals.js
@@ -12,6 +12,16 @@ function closeTutorial() {
   localStorage.setItem('vice_tutorial_shown', '1');
   document.getElementById('tutorial-modal').classList.add('hidden');
 }
+function showManualCopyModal(text) {
+  const input = document.getElementById('manual-copy-text');
+  input.value = text;
+  document.getElementById('manual-copy-modal').classList.remove('hidden');
+  input.focus();
+  input.select();
+}
+function closeManualCopyModal() {
+  document.getElementById('manual-copy-modal').classList.add('hidden');
+}
 function showRestartModal() {
   document.getElementById('restart-modal').classList.remove('hidden');
 }

--- a/vice/ui/scripts/settings.js
+++ b/vice/ui/scripts/settings.js
@@ -294,8 +294,10 @@ async function onHomeTunnelToggle(el) {
 
 function copyTunnelUrl() {
   if (!tunnelUrl) { toast('Enable the tunnel first', 'err'); return; }
-  copyToClipboard(tunnelUrl).then(ok =>
-    toast(ok ? 'Public URL copied!' : 'Could not copy', ok ? 'ok' : 'err'));
+  copyToClipboard(tunnelUrl).then(ok => {
+    if (ok) toast('Public URL copied!', 'ok');
+    else showManualCopyModal(tunnelUrl);
+  });
 }
 
 async function saveSettings() {

--- a/vice/ui/styles/home.css
+++ b/vice/ui/styles/home.css
@@ -38,7 +38,15 @@
 .buffer-viz { position: relative; height: 72px; display: flex; align-items: flex-end; gap: 3px;
   padding: 8px 0; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); margin-bottom: 16px; }
 .buffer-bar { flex: 1; background: linear-gradient(180deg, var(--accent), rgba(var(--accent-rgb),0.2));
-  border-radius: 1.5px; min-height: 4px; transition: height .4s var(--ease); }
+  border-radius: 1.5px; height: 56px; transform-origin: bottom;
+  transform: scaleY(var(--s1, 0.4));
+  animation: buffer-pulse 2.8s ease-in-out infinite; }
+@keyframes buffer-pulse {
+  0%, 100% { transform: scaleY(var(--s1, 0.4)); }
+  33%      { transform: scaleY(var(--s2, 0.7)); }
+  66%      { transform: scaleY(var(--s3, 0.25)); }
+}
+.buffer-viz.viz-paused .buffer-bar { animation-play-state: paused; }
 
 .hero-card-rows { display: flex; flex-direction: column; gap: 10px; position: relative; }
 .hero-row { display: flex; justify-content: space-between; align-items: center; font-size: 13px; }

--- a/vice/ui/styles/modals.css
+++ b/vice/ui/styles/modals.css
@@ -24,10 +24,10 @@
 .modal-ft-left { font-size: 12px; color: var(--text-dim); }
 
 /* Tutorial / restart / wf-mic */
-#tutorial-modal, #restart-modal, #wf-mic-modal { position: fixed; inset: 0; z-index: 3000;
+#tutorial-modal, #restart-modal, #wf-mic-modal, #manual-copy-modal { position: fixed; inset: 0; z-index: 3000;
   display: grid; place-items: center; padding: 24px;
   background: rgba(0,0,0,0.7); backdrop-filter: blur(10px); animation: fadeIn .25s; }
-#tutorial-modal.hidden, #restart-modal.hidden, #wf-mic-modal.hidden { display: none; }
+#tutorial-modal.hidden, #restart-modal.hidden, #wf-mic-modal.hidden, #manual-copy-modal.hidden { display: none; }
 @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
 
 .tutorial-box { background: var(--bg-card); border-radius: var(--r-card); padding: 30px;
@@ -51,6 +51,9 @@
 .restart-cmd { font-size: 13px; background: rgba(0,0,0,0.4); border: 1px solid var(--line);
   border-radius: var(--r-sm); padding: 12px 14px; user-select: all; color: var(--accent); }
 .restart-actions { display: flex; justify-content: flex-end; gap: 8px; }
+.manual-copy-input { font-size: 13px; background: rgba(0,0,0,0.4); border: 1px solid var(--line);
+  border-radius: var(--r-sm); padding: 12px 14px; color: var(--accent); width: 100%; outline: none; }
+.manual-copy-input:focus { border-color: var(--accent); }
 .wf-mic-box { width: min(560px, 100%); }
 .wf-mic-note { font-size: 13px; color: var(--text-dim); line-height: 1.6; }
 .wf-mic-actions { display: flex; justify-content: flex-end; gap: 8px; flex-wrap: wrap; }

--- a/vice/ui/styles/settings.css
+++ b/vice/ui/styles/settings.css
@@ -36,6 +36,10 @@ select:focus, input[type=text]:focus, input[type=number]:focus {
 select { cursor: pointer; padding-right: 32px; appearance: none;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23a6a6a6' stroke-width='2'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
   background-repeat: no-repeat; background-position: right 10px center; }
+/* Native dropdown popups ignore the page background but inherit the text
+   color, leaving white-on-white menus on some desktops (KDE Plasma 6 +
+   Wayland). System colors hand contrast back to the OS menu renderer. */
+select option { background-color: Menu; color: MenuText; }
 input[type=text] { width: 240px; }
 input[type=number] { width: 100px; }
 


### PR DESCRIPTION
### Root cause

QtWebEngine ran with no Chromium flags. Three separate issue reports trace back to that:

- **#79 / #68 (grey or black clip playback, UI responsive, file plays fine externally)**: Chromium's hardware video decode is broken on many Linux GPU/driver combos and renders the `<video>` element as a blank rectangle.
- **#82 (vice-app segfault on Arch + NVIDIA)**: "GBM is not supported... Fallback to Vulkan rendering in Chromium" followed by a crash. The Vulkan fallback path segfaults on NVIDIA setups without GBM. The same log also shows Qt complaining about a C locale.
- **#83 (memory grows until the system freezes, only while the window is open)**: the home screen's rolling-buffer bars were animated by a 500 ms JS timer mutating element heights forever, keeping the renderer compositing and accumulating memory.

### Changes

- vice-app sets `QTWEBENGINE_CHROMIUM_FLAGS` before QtWebEngine initialises: `--disable-accelerated-video-decode --disable-gpu-memory-buffer-video-frames --autoplay-policy=no-user-gesture-required`, plus `--disable-features=Vulkan` on NVIDIA. Software decode of one short local clip is cheap and always renders. Escape hatches: set `QTWEBENGINE_CHROMIUM_FLAGS` yourself to replace everything, or `VICE_WEBVIEW_FLAGS` to append.
- `LC_ALL`/`LANG` are set to `C.UTF-8` when the process has a C/POSIX/empty locale (typical for systemd-launched sessions).
- If the Qt backend raises before opening a window, vice-app retries once on GTK/WebKit2GTK (with the existing XWayland workarounds) before the existing browser fallback.
- The buffer bars now animate with a pure CSS `scaleY` keyframe (compositor-only, near-zero cost) and pause when the window is hidden or another tab is active. The JS timer is gone.
- `<meta name="color-scheme" content="dark">` plus `select option { background-color: Menu; color: MenuText; }` make native dropdown popups readable on KDE Plasma 6 / Wayland (#85, the fix the reporter validated).
- When no clipboard backend succeeds, the UI opens a manual-copy dialog with the text pre-selected instead of a dead-end "Could not copy" toast (#76/#78 UX half; the installer half comes in the packaging branch).

### Verification

- `python -m unittest discover tests/` — 99 tests pass on this branch (new: webview env flag builder, locale handling, UI static checks for the meta tag/modal/CSS animation).
- Verified reasoning, not hardware: the NVIDIA Vulkan crash and Plasma 6 dropdown rendering need confirmation from the reporters; both changes are conservative and scoped.
- Manual check: run `vice-app`, open a clip (should play, not grey), leave the window open on Home and watch RSS stay flat, click a share-link copy button on a system without wl-clipboard.

Closes #79, closes #68, closes #82, closes #83, closes #85.
