### PR TITLE
Share links: drop serveo fallback, surface tunnel errors, themed embeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,9 @@ exec dbus-update-activation-environment --systemd WAYLAND_DISPLAY DISPLAY DBUS_S
 
 Restart your compositor session, then `systemctl --user restart vice.service`.
 
-**Share link only works on my local network** → enable the tunnel in Settings → Sharing, and make sure `cloudflared` is installed.
+**Share link only works on my local network** → enable the tunnel in Settings → Sharing, and make sure `cloudflared` is installed. cloudflared is the only supported tunnel; if it is missing, Vice shows an error in the UI instead of generating a public link.
+
+**Clip won't embed on Discord** → Discord only inlines videos up to about 50 MB and fetches them when the message is posted. If the clip is larger, trim it or lower the CRF/resolution. Links also stop working when the Vice daemon restarts, since a fresh tunnel URL is generated each run; repost the link after a restart.
 
 **UI looks like plain unstyled HTML right after an upgrade** → the previous daemon is still running with the old Python code in memory. `vice stop && vice-app` once (or relaunch from your app menu). `vice-app` self-heals from the next upgrade onward.
 

--- a/tests/test_share_server.py
+++ b/tests/test_share_server.py
@@ -171,6 +171,26 @@ class ShareServerSecurityTests(unittest.IsolatedAsyncioTestCase):
         async with self.client.get(f"{public_base}/v/mkv_clip") as resp:
             self.assertEqual(resp.status, 200)
 
+    async def test_embed_page_carries_theme_color_and_player_metadata(self) -> None:
+        public_base = self.server.public_base_url()
+        async with self.client.get(f"{public_base}/c/test_clip") as resp:
+            self.assertEqual(resp.status, 200)
+            html = await resp.text()
+
+        self.assertIn('name="theme-color"', html)
+        self.assertIn('content="#0099ff"', html)
+        self.assertIn("twitter:player:stream", html)
+        self.assertIn("og:video:type", html)
+
+    async def test_embed_color_rejects_non_hex_values(self) -> None:
+        self.server.cfg.sharing.embed_color = "<script>alert(1)</script>"
+        public_base = self.server.public_base_url()
+        async with self.client.get(f"{public_base}/c/test_clip") as resp:
+            html = await resp.text()
+
+        self.assertNotIn("<script>alert(1)</script>", html)
+        self.assertIn('content="#0099ff"', html)
+
     async def test_public_server_blocks_privileged_routes_and_mutation(self) -> None:
         public_base = f"http://127.0.0.1:{self.public_port}"
 
@@ -432,3 +452,68 @@ class ShareServerClipBroadcastTests(unittest.IsolatedAsyncioTestCase):
 
             self.assertEqual(messages[-1]["type"], "clip_saved")
             self.assertEqual(messages[-1]["clip"]["duration"], 6.5)
+
+
+@unittest.skipUnless(ShareServer is not None, "aiohttp is not installed")
+class ShareServerTunnelTests(unittest.IsolatedAsyncioTestCase):
+    """The serveo SSH fallback is gone: cloudflared or a clear error."""
+
+    def _server(self) -> "ShareServer":
+        return ShareServer(Config(sharing=SharingConfig(cloudflare_tunnel=True)))
+
+    async def test_missing_cloudflared_broadcasts_tunnel_error(self) -> None:
+        server = self._server()
+        server.broadcast = mock.AsyncMock()
+
+        with mock.patch("vice.share.shutil.which", return_value=None):
+            with mock.patch(
+                "vice.share.asyncio.create_subprocess_exec",
+                new=mock.AsyncMock(),
+            ) as exec_mock:
+                await server._start_tunnel(8766)
+
+        exec_mock.assert_not_awaited()
+        msg = server.broadcast.await_args.args[0]
+        self.assertEqual(msg["type"], "tunnel_error")
+        self.assertIn("cloudflared", msg["error"])
+
+    async def test_no_serveo_fallback_remains(self) -> None:
+        self.assertFalse(hasattr(ShareServer, "_read_serveo_url"))
+
+        # Even with ssh available, nothing must be spawned when
+        # cloudflared is missing.
+        server = self._server()
+        server.broadcast = mock.AsyncMock()
+        with mock.patch(
+            "vice.share.shutil.which",
+            side_effect=lambda name: "/usr/bin/ssh" if name == "ssh" else None,
+        ):
+            with mock.patch(
+                "vice.share.asyncio.create_subprocess_exec",
+                new=mock.AsyncMock(),
+            ) as exec_mock:
+                await server._start_tunnel(8766)
+
+        exec_mock.assert_not_awaited()
+
+    async def test_cloudflared_exit_without_url_reports_error(self) -> None:
+        server = self._server()
+        server.broadcast = mock.AsyncMock()
+
+        class _Stdout:
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                raise StopAsyncIteration
+
+        proc = mock.Mock()
+        proc.stdout = _Stdout()
+        proc.returncode = 1
+        server._tunnel_proc = proc
+
+        await server._read_cloudflare_url()
+
+        msg = server.broadcast.await_args.args[0]
+        self.assertEqual(msg["type"], "tunnel_error")
+        self.assertIn("exited", msg["error"])

--- a/vice/config.py
+++ b/vice/config.py
@@ -104,10 +104,13 @@ class SharingConfig:
     port: int = 8765
     # Port for the public share-only server. Defaults to sharing.port + 1.
     public_port: Optional[int] = None
-    # Expose via a public tunnel (cloudflared if available, SSH/serveo as fallback).
+    # Expose via a Cloudflare quick tunnel (requires the cloudflared binary).
     cloudflare_tunnel: bool = True
     # Override the public base URL shown in share links (e.g. if behind reverse proxy).
     base_url: Optional[str] = None
+    # Accent color for share-page embeds (Discord sidebar strip etc.).
+    # Synced from the UI theme; must be a #rrggbb hex value.
+    embed_color: str = "#0099ff"
 
 
 @dataclass

--- a/vice/share.py
+++ b/vice/share.py
@@ -8,6 +8,7 @@ WebSocket event types (server → client):
   {"type": "clip_deleted", "slug":  "..."}
   {"type": "status",       "recording": bool, "backend": "..."}
   {"type": "tunnel_url",   "url":   "https://..."}
+  {"type": "tunnel_error", "error": "..."}
 """
 
 from __future__ import annotations
@@ -16,6 +17,7 @@ import asyncio
 import copy
 import json
 import logging
+import re
 import shutil
 import socket
 import subprocess
@@ -254,6 +256,8 @@ _EMBED_PAGE = """\
 <!DOCTYPE html>
 <html><head>
   <meta charset="utf-8">
+  <meta name="theme-color"              content="{color}">
+  <meta property="og:site_name"         content="Vice">
   <meta property="og:type"              content="video.other">
   <meta property="og:title"             content="{title}">
   <meta property="og:description"       content="Clipped with Vice on Linux">
@@ -265,6 +269,7 @@ _EMBED_PAGE = """\
   <meta property="og:image"             content="{thumb_url}">
   <meta name="twitter:card"             content="player">
   <meta name="twitter:player"           content="{video_url}">
+  <meta name="twitter:player:stream"    content="{video_url}">
   <meta name="twitter:player:width"     content="{width}">
   <meta name="twitter:player:height"    content="{height}">
   <title>{title}</title>
@@ -555,8 +560,16 @@ class ShareServer:
             thumb_url=f"{base}/t/{slug}",
             width=meta.get("width", 1920),
             height=meta.get("height", 1080),
+            color=self._embed_color(),
         )
         return web.Response(text=html, content_type="text/html")
+
+    def _embed_color(self) -> str:
+        """Validated embed accent color (guards against HTML injection)."""
+        color = getattr(self.cfg.sharing, "embed_color", "") or ""
+        if re.fullmatch(r"#[0-9a-fA-F]{6}", color):
+            return color
+        return "#0099ff"
 
     async def _video(self, req: web.Request) -> web.Response:
         slug = req.match_info["slug"]
@@ -891,8 +904,13 @@ class ShareServer:
         ensure_buffer_covers_clip_presets(new_cfg)
 
         old_cfg = copy.deepcopy(self.cfg)
+        # embed_color is read per-request, so changing it (the UI syncs it
+        # on theme switches) must not demand a daemon restart.
+        old_sharing = copy.deepcopy(old_cfg.sharing)
+        new_sharing = copy.deepcopy(new_cfg.sharing)
+        old_sharing.embed_color = new_sharing.embed_color = ""
         restart_required = (
-            old_cfg.sharing != new_cfg.sharing
+            old_sharing != new_sharing
             or old_cfg.recording.gsr_args != new_cfg.recording.gsr_args
         )
 
@@ -974,36 +992,43 @@ class ShareServer:
             self._ws_clients.discard(ws)
         return ws
 
-    # ── Tunnel (Cloudflare → SSH/serveo fallback) ─────────────────────────────
+    # ── Tunnel (Cloudflare quick tunnel) ──────────────────────────────────────
+    #
+    # cloudflared is the only supported tunnel. There used to be an SSH
+    # fallback via serveo.net, but it produced broken links (serveo prints
+    # promotional URLs that got parsed as the tunnel address), is operated
+    # by an unaccountable third party, and silently man-in-the-middles all
+    # traffic. Failing loudly with an install hint is strictly better.
 
     async def _start_tunnel(self, port: int) -> None:
-        if shutil.which("cloudflared"):
-            log.info("Starting Cloudflare Tunnel on port %d", port)
+        if not shutil.which("cloudflared"):
+            await self._tunnel_failed(
+                "cloudflared is not installed. Install it to get public share "
+                "links (https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/), "
+                "or turn off the public tunnel in Settings."
+            )
+            return
+        log.info("Starting Cloudflare Tunnel on port %d", port)
+        try:
             self._tunnel_proc = await asyncio.create_subprocess_exec(
                 "cloudflared", "tunnel", "--url", f"http://localhost:{port}",
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
             )
-            asyncio.create_task(self._read_cloudflare_url())
-        elif shutil.which("ssh"):
-            log.info("cloudflared not found; using SSH tunnel via serveo.net on port %d", port)
-            self._tunnel_proc = await asyncio.create_subprocess_exec(
-                "ssh",
-                "-o", "StrictHostKeyChecking=no",
-                "-o", "ServerAliveInterval=30",
-                "-o", "ExitOnForwardFailure=yes",
-                "-R", f"80:localhost:{port}",
-                "serveo.net",
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.STDOUT,
-            )
-            asyncio.create_task(self._read_serveo_url())
-        else:
-            log.warning("No tunnel available (install cloudflared for public share links)")
+        except OSError as exc:
+            await self._tunnel_failed(f"cloudflared failed to start: {exc}")
+            return
+        asyncio.create_task(self._read_cloudflare_url())
+
+    async def _tunnel_failed(self, reason: str) -> None:
+        log.error("Public share tunnel unavailable: %s", reason)
+        self._tunnel_url = None
+        await self.broadcast({"type": "tunnel_error", "error": reason})
 
     async def _read_cloudflare_url(self) -> None:
         assert self._tunnel_proc and self._tunnel_proc.stdout
-        async for raw in self._tunnel_proc.stdout:
+        proc = self._tunnel_proc
+        async for raw in proc.stdout:
             line = raw.decode()
             if "trycloudflare.com" in line or ".cloudflare.com" in line:
                 for word in line.split():
@@ -1012,15 +1037,11 @@ class ShareServer:
                         log.info("Cloudflare Tunnel URL: %s", self._tunnel_url)
                         await self.broadcast({"type": "tunnel_url", "url": self._tunnel_url})
                         break
-
-    async def _read_serveo_url(self) -> None:
-        assert self._tunnel_proc and self._tunnel_proc.stdout
-        async for raw in self._tunnel_proc.stdout:
-            line = raw.decode()
-            # serveo prints: "Forwarding HTTP traffic from https://xxxx.serveo.net"
-            for word in line.split():
-                if word.startswith("https://") and "serveo.net" in word:
-                    self._tunnel_url = word.strip()
-                    log.info("serveo.net Tunnel URL: %s", self._tunnel_url)
-                    await self.broadcast({"type": "tunnel_url", "url": self._tunnel_url})
-                    break
+        # stdout closed: cloudflared exited. If that happened before a URL
+        # was ever printed, surface it instead of leaving the UI waiting.
+        if self._tunnel_url is None and proc is self._tunnel_proc:
+            rc = proc.returncode if proc.returncode is not None else await proc.wait()
+            await self._tunnel_failed(
+                f"cloudflared exited (code {rc}) before providing a tunnel URL. "
+                "Check your network or run it manually to see the error."
+            )

--- a/vice/ui/scripts/theme.js
+++ b/vice/ui/scripts/theme.js
@@ -16,5 +16,13 @@ function setTheme(name, persist = true) {
   document.documentElement.style.setProperty('--accent', t.hex);
   document.documentElement.style.setProperty('--accent-rgb', t.rgb);
   document.querySelectorAll('.swatch').forEach(s => s.classList.toggle('active', s.dataset.theme === name));
-  if (persist) localStorage.setItem('vice-theme', name);
+  if (persist) {
+    localStorage.setItem('vice-theme', name);
+    // Keep share-page embeds (Discord sidebar strip) on the same accent.
+    fetch('/api/config', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sharing: { embed_color: t.hex } }),
+    }).catch(() => {});
+  }
 }

--- a/vice/ui/scripts/ws.js
+++ b/vice/ui/scripts/ws.js
@@ -46,6 +46,13 @@ function handleWS(msg) {
     rt.textContent = msg.url;
     ro.classList.add('active');
     toast('Public share link ready!', 'ok');
+  } else if (msg.type === 'tunnel_error') {
+    tunnelUrl = null;
+    const ro = document.getElementById('tunnel-readout');
+    const rt = document.getElementById('tunnel-readout-text');
+    if (rt) rt.textContent = msg.error || 'Public share tunnel unavailable';
+    if (ro) ro.classList.remove('active');
+    toast(msg.error || 'Public share tunnel unavailable', 'err');
   } else if (msg.type === 'session_start') {
     setRecStatus(true, runtimeBackend, true);
     toast(`Session recording started — ${hotkeyLabel()} marks highlights, double-tap to stop`, 'ok');


### PR DESCRIPTION
### Root cause

- **#78 (copied share link goes to a serveo upsell page)**: when cloudflared was missing, the share server silently fell back to an SSH tunnel through serveo.net and parsed the tunnel URL by grabbing the first `https://...serveo.net...` token from the output. serveo prints promotional "ssh_nudge" URLs, so that token was often `https://console.serveo.net/settings?...`. The fallback also routed all clip traffic through an unaccountable third party.
- **#38**: embeds rendered with Discord's default gray strip; there was no theme-color metadata.
- **#77 (videos not embedding)**: most likely stale tunnel URLs (a new quick-tunnel hostname is generated each daemon restart) or Discord's ~50 MB inline limit. Embed metadata is now more complete and the limits are documented; needs reporter confirmation.

### Changes

- cloudflared is the only tunnel. When it is missing, fails to spawn, or exits before printing a URL, the daemon logs the reason and broadcasts a `tunnel_error` WebSocket message; the UI shows it in the tunnel readout and as a toast with an install hint. No silent fallback, no mystery links.
- Embed page gains `theme-color` (synced from the UI accent on theme change, persisted as `sharing.embed_color`), `og:site_name`, and `twitter:player:stream`. The color is validated server-side as `#rrggbb` so config values can't inject HTML. Changing it does not trigger the "restart required" prompt.
- README: cloudflared requirement, Discord 50 MB inline-embed limit, quick-tunnel URLs change across restarts.

### Verification

- `python -m unittest discover tests/` — 96 tests pass on this branch. New tests: no process spawned without cloudflared (even with ssh present), `tunnel_error` broadcast on missing binary and on early cloudflared exit, embed page metadata, hex-color injection guard.
- Manual: uninstall cloudflared, start the daemon with sharing on; the UI should show the tunnel error. Reinstall, restart, copy a share link, post in Discord (clip under 50 MB) and confirm the colored embed.

Closes #78, closes #38. Comment on #77 asking the reporter to retest with a sub-50 MB clip and a fresh link; close if confirmed or keep open pending their reply.
