### PR TITLE
Hotkeys survive keyboard unplug/replug

### DIFF
--- a/tests/test_hotkey.py
+++ b/tests/test_hotkey.py
@@ -1,0 +1,109 @@
+import asyncio
+import unittest
+from unittest import mock
+
+from vice.hotkey import HotkeyListener
+
+
+class _FakeDevice:
+    """Stands in for evdev.InputDevice."""
+
+    def __init__(self, path: str, *, dies: bool = False) -> None:
+        self.path = path
+        self.name = f"fake-{path}"
+        self.closed = False
+        self._dies = dies
+
+    async def async_read_loop(self):
+        if self._dies:
+            raise OSError(19, "No such device")
+        while True:
+            await asyncio.sleep(3600)
+            yield  # pragma: no cover — never reached
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class HotkeyHotplugTests(unittest.IsolatedAsyncioTestCase):
+    async def test_listener_reattaches_after_keyboard_replug(self) -> None:
+        """Regression test for #65: a disconnected keyboard must not leave
+        the listener stuck until a daemon restart."""
+        dying = _FakeDevice("/dev/input/event2", dies=True)
+        replug = _FakeDevice("/dev/input/event5")
+        # Scan results over time: device present, gone, replugged.
+        scans = [[dying], [], [replug]]
+
+        def _fake_find(skip_paths=None):
+            batch = scans.pop(0) if scans else []
+            skip = skip_paths or set()
+            return [d for d in batch if d.path not in skip]
+
+        availability: list[bool] = []
+        listener = HotkeyListener()
+        listener.on_availability_change = availability.append
+
+        with mock.patch("vice.hotkey._find_keyboards", side_effect=_fake_find):
+            with mock.patch("vice.hotkey.RESCAN_INTERVAL", 0.03):
+                await listener.start()
+                self.assertTrue(listener.available)
+
+                # Wait until the supervisor has reaped the dead device and
+                # attached the replugged one.
+                for _ in range(100):
+                    await asyncio.sleep(0.02)
+                    if replug.path in listener._listeners and listener.available:
+                        break
+                self.assertIn(replug.path, listener._listeners)
+                self.assertNotIn(dying.path, listener._listeners)
+                self.assertTrue(listener.available)
+                await listener.stop()
+
+        # Availability flapped: down when the keyboard died, up on replug.
+        self.assertIn(False, availability)
+        self.assertEqual(availability[-1], True)
+        self.assertTrue(dying.closed)
+
+    async def test_start_without_keyboards_keeps_watching(self) -> None:
+        keyboard = _FakeDevice("/dev/input/event3")
+        scans = [[], [keyboard]]
+
+        def _fake_find(skip_paths=None):
+            batch = scans.pop(0) if scans else []
+            skip = skip_paths or set()
+            return [d for d in batch if d.path not in skip]
+
+        listener = HotkeyListener()
+        with mock.patch("vice.hotkey._find_keyboards", side_effect=_fake_find):
+            with mock.patch("vice.hotkey.RESCAN_INTERVAL", 0.03):
+                await listener.start()
+                self.assertFalse(listener.available)
+
+                for _ in range(100):
+                    await asyncio.sleep(0.02)
+                    if listener.available:
+                        break
+                self.assertTrue(listener.available)
+                await listener.stop()
+
+    async def test_stop_cancels_supervisor_and_listeners(self) -> None:
+        keyboard = _FakeDevice("/dev/input/event4")
+
+        def _fake_find(skip_paths=None):
+            skip = skip_paths or set()
+            return [keyboard] if keyboard.path not in skip else []
+
+        listener = HotkeyListener()
+        with mock.patch("vice.hotkey._find_keyboards", side_effect=_fake_find):
+            await listener.start()
+            supervisor = listener._supervisor
+            await listener.stop()
+
+        self.assertEqual(listener._listeners, {})
+        self.assertIsNone(listener._supervisor)
+        self.assertTrue(supervisor.cancelled() or supervisor.done())
+        self.assertTrue(keyboard.closed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vice/hotkey.py
+++ b/vice/hotkey.py
@@ -41,16 +41,28 @@ AsyncCallback = Callable[[], Coroutine]
 # Seconds within which a second press counts as a double-tap.
 DOUBLE_TAP_WINDOW = 0.35
 
+# How often the supervisor rescans /dev/input for plugged/unplugged
+# keyboards. Scanning is a handful of open/ioctl/close calls; 3 s keeps
+# hotkeys working within a blink of replugging a keyboard.
+RESCAN_INTERVAL = 3.0
+
 
 class HotkeyListener:
     def __init__(self) -> None:
         self._bindings: dict[str, list[AsyncCallback]] = {}
         self._double_bindings: dict[str, list[AsyncCallback]] = {}
-        self._tasks: list[asyncio.Task] = []
+        # One (device, listener task) per device path, supervised for
+        # hotplug. The device handle is kept so stop()/reaping can close
+        # it even when the task never got to run.
+        self._listeners: dict[str, tuple[InputDevice, asyncio.Task]] = {}
+        self._supervisor: asyncio.Task | None = None
         self._running = False
         # Per-key pending single-tap timer tasks
         self._pending: dict[str, asyncio.Task] = {}
         self.available = False
+        # Optional: called with the new availability whenever it changes
+        # (e.g. last keyboard unplugged, or one plugged back in).
+        self.on_availability_change: Callable[[bool], None] | None = None
 
     def on(self, key_name: str, callback: AsyncCallback) -> None:
         """
@@ -77,32 +89,76 @@ class HotkeyListener:
         self._pending.clear()
 
     async def start(self) -> None:
-        """Discover keyboards and spawn a listener task per device."""
-        keyboards = _find_keyboards()
-        self.available = bool(keyboards)
-        if not keyboards:
+        """Discover keyboards, then keep watching for hotplug events.
+
+        Listener tasks die when their device disappears (keyboard
+        unplugged, errno 19); the supervisor reaps them and attaches to
+        new devices, so hotkeys survive unplug/replug without a daemon
+        restart.
+        """
+        self._running = True
+        self._attach_new_keyboards(initial=True)
+        if not self._listeners:
             log.warning(
                 "No keyboard devices found in /dev/input/. "
                 "Ensure the udev uaccess rule is installed, then run: "
-                "sudo udevadm control --reload && sudo udevadm trigger"
+                "sudo udevadm control --reload && sudo udevadm trigger. "
+                "Vice keeps watching for keyboards every %.0f s.",
+                RESCAN_INTERVAL,
             )
-            return
-
-        log.info("Listening for hotkeys on %d device(s)", len(keyboards))
-        self._running = True
-        for dev in keyboards:
-            task = asyncio.create_task(self._listen(dev))
-            self._tasks.append(task)
+        self._supervisor = asyncio.create_task(self._supervise())
 
     async def stop(self) -> None:
         self._running = False
+        if self._supervisor:
+            self._supervisor.cancel()
+            self._supervisor = None
         for t in self._pending.values():
             t.cancel()
         self._pending.clear()
-        for t in self._tasks:
-            t.cancel()
-        await asyncio.gather(*self._tasks, return_exceptions=True)
-        self._tasks.clear()
+        tasks = []
+        for dev, task in self._listeners.values():
+            task.cancel()
+            tasks.append(task)
+            _close_quietly(dev)
+        await asyncio.gather(*tasks, return_exceptions=True)
+        self._listeners.clear()
+
+    async def _supervise(self) -> None:
+        try:
+            while self._running:
+                await asyncio.sleep(RESCAN_INTERVAL)
+                # Reap listeners whose device died.
+                for path, (dev, task) in list(self._listeners.items()):
+                    if task.done():
+                        _close_quietly(dev)
+                        del self._listeners[path]
+                self._attach_new_keyboards()
+        except asyncio.CancelledError:
+            pass
+
+    def _attach_new_keyboards(self, initial: bool = False) -> None:
+        for dev in _find_keyboards(skip_paths=set(self._listeners)):
+            log.info(
+                "Listening for hotkeys on %s (%s)%s",
+                dev.path, dev.name, "" if initial else " [hotplug]",
+            )
+            self._listeners[dev.path] = (dev, asyncio.create_task(self._listen(dev)))
+        self._set_available(bool(self._listeners))
+
+    def _set_available(self, value: bool) -> None:
+        if value == self.available:
+            return
+        self.available = value
+        if value:
+            log.info("Keyboard available — hotkeys active")
+        else:
+            log.warning("All keyboards disconnected — hotkeys inactive until one reappears")
+        if self.on_availability_change:
+            try:
+                self.on_availability_change(value)
+            except Exception:
+                log.exception("Hotkey availability callback raised")
 
     async def _listen(self, dev: InputDevice) -> None:
         log.debug("Listening on %s (%s)", dev.path, dev.name)
@@ -122,9 +178,14 @@ class HotkeyListener:
                 for key_name in pressed:
                     await self._handle_press(key_name)
         except OSError as exc:
-            log.warning("Device %s disconnected: %s", dev.path, exc)
+            log.warning(
+                "Device %s disconnected: %s — will reattach when it returns",
+                dev.path, exc,
+            )
         except asyncio.CancelledError:
             pass
+        finally:
+            _close_quietly(dev)
 
     async def _handle_press(self, key_name: str) -> None:
         has_single = bool(self._bindings.get(key_name))
@@ -173,28 +234,43 @@ async def _safe_call(cb: AsyncCallback, key_name: str) -> None:
         log.exception("Hotkey callback for %s raised an exception", key_name)
 
 
-def _find_keyboards() -> list[InputDevice]:
-    """Return all readable /dev/input devices that have key capabilities."""
+def _close_quietly(dev: InputDevice) -> None:
+    try:
+        dev.close()
+    except Exception:
+        pass
+
+
+def _find_keyboards(skip_paths: set[str] | None = None) -> list[InputDevice]:
+    """Return readable /dev/input keyboards, skipping already-known paths."""
+    skip = skip_paths or set()
     devices: list[InputDevice] = []
     for path in evdev.list_devices():
+        if path in skip:
+            continue
         try:
             dev = InputDevice(path)
-            caps = dev.capabilities()
-            if ecodes.EV_KEY in caps:
-                # Require that the device has at least some normal keys
-                keys = caps[ecodes.EV_KEY]
-                if ecodes.KEY_A in keys or ecodes.KEY_SPACE in keys:
-                    devices.append(dev)
         except (PermissionError, OSError):
-            # Not readable — user not in input group, or not a keyboard
+            # Not readable — user not in input group, or device vanished.
+            continue
+        try:
+            # Require that the device has at least some normal keys.
+            keys = dev.capabilities().get(ecodes.EV_KEY, [])
+            if ecodes.KEY_A in keys or ecodes.KEY_SPACE in keys:
+                devices.append(dev)
+                continue
+        except OSError:
             pass
+        _close_quietly(dev)
     return devices
-
 
 
 def can_access_hotkeys() -> bool:
     """Return True when at least one keyboard input device is readable."""
-    return bool(_find_keyboards())
+    keyboards = _find_keyboards()
+    for dev in keyboards:
+        _close_quietly(dev)
+    return bool(keyboards)
 
 def list_available_keys() -> list[str]:
     """Return all KEY_* names evdev knows about (for documentation/config help)."""

--- a/vice/main.py
+++ b/vice/main.py
@@ -166,6 +166,7 @@ class ViceDaemon:
 
         # Hotkeys
         self._bind_hotkeys()
+        self.hotkeys.on_availability_change = self._on_hotkey_availability
         clip_key = self.cfg.hotkeys.clip
 
         PID_FILE.write_text(str(os.getpid()))
@@ -247,6 +248,20 @@ class ViceDaemon:
 
         await stop_event.wait()
         await self._shutdown(server)
+
+    def _on_hotkey_availability(self, available: bool) -> None:
+        """Keep the UI banner truthful when keyboards unplug/replug."""
+        self.hotkeys_available = available
+        if self.share:
+            asyncio.create_task(
+                self.share.broadcast({
+                    "type": "status", "recording": self._ready, "ready": self._ready,
+                    "backend": self.recorder.name,
+                    "session_active": self._session_active,
+                    "clip_key": self.cfg.hotkeys.clip,
+                    "hotkeys_available": available,
+                })
+            )
 
     def _recording_signature(self) -> str:
         """Stable representation of recording config for live-apply checks."""


### PR DESCRIPTION
### Root cause (#65)

`HotkeyListener.start()` spawned one task per keyboard at startup and never looked at `/dev/input` again. Unplugging a keyboard killed its listener task with errno 19 and hotkeys stayed dead until a daemon restart. The reporter noted `systemctl restart` right after unplugging often did not fix it: the restart raced device re-enumeration, scanned an empty device list, and gave up the same way.

### Changes

- A supervisor task rescans `/dev/input` every 3 seconds: reaps listener tasks whose device died (closing the device handle), attaches to newly plugged keyboards, and logs both transitions.
- `available` updates live and the daemon broadcasts it via the existing status WebSocket message, so the UI's "hotkeys unavailable" banner reflects reality instead of the state at boot.
- Device handles are closed on every path now (rescan probes, reaping, stop, and cancel-before-run), so the periodic scan does not leak file descriptors.

### Verification

- `python -m unittest discover tests/` — 94 tests pass on this branch. New tests/test_hotkey.py simulates a device dying and a replug and asserts the listener reattaches, availability flaps down/up, devices get closed, and stop() tears everything down.
- Manual: start the daemon, unplug the keyboard, replug it, and press the clip key within ~3 seconds of replugging; check the log for the "disconnected ... will reattach" and "[hotplug]" lines.

Closes #65.
