### PR TITLE
Installer: build gpu-screen-recorder as the user, install clipboard tools

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -200,6 +200,14 @@ install_pkgs_pacman() {
         info "Will install NVIDIA utilities"
     fi
 
+    # Clipboard tool for "Copy share link" — the in-page clipboard API is
+    # unreliable in QtWebEngine on http:// origins, so the app shells out.
+    if [[ "$SESSION" == "wayland" ]]; then
+        pkgs+=(wl-clipboard)
+    else
+        pkgs+=(xclip)
+    fi
+
     # wf-recorder is best-effort — only needed if a user explicitly sets
     # recording.backend=wf-recorder in their config. GSR is the auto default,
     # installed separately via install_gpu_screen_recorder.
@@ -233,6 +241,15 @@ install_pkgs_apt() {
         sudo apt-get install -y "$p" >/dev/null 2>&1 || \
             warn "$p not available via apt; will fall back to PyPI wheel."
     done
+    # Clipboard tool for "Copy share link" — the in-page clipboard API is
+    # unreliable in QtWebEngine on http:// origins, so the app shells out.
+    if [[ "$SESSION" == "wayland" ]]; then
+        sudo apt-get install -y wl-clipboard >/dev/null 2>&1 || \
+            warn "wl-clipboard not available; copying links will offer a manual-copy dialog."
+    else
+        sudo apt-get install -y xclip >/dev/null 2>&1 || \
+            warn "xclip not available; copying links will offer a manual-copy dialog."
+    fi
     if [[ "$SESSION" == "wayland" ]] && ! command -v wf-recorder &>/dev/null; then
         sudo apt-get install -y wf-recorder >/dev/null 2>&1 || true
     fi
@@ -259,6 +276,15 @@ install_pkgs_dnf() {
         sudo dnf install -y "$p" >/dev/null 2>&1 || \
             warn "$p not available via dnf; will fall back to PyPI wheel."
     done
+    # Clipboard tool for "Copy share link" — the in-page clipboard API is
+    # unreliable in QtWebEngine on http:// origins, so the app shells out.
+    if [[ "$SESSION" == "wayland" ]]; then
+        sudo dnf install -y wl-clipboard >/dev/null 2>&1 || \
+            warn "wl-clipboard not available; copying links will offer a manual-copy dialog."
+    else
+        sudo dnf install -y xclip >/dev/null 2>&1 || \
+            warn "xclip not available; copying links will offer a manual-copy dialog."
+    fi
     if [[ "$SESSION" == "wayland" ]] && ! command -v wf-recorder &>/dev/null; then
         sudo dnf install -y wf-recorder >/dev/null 2>&1 || true
     fi
@@ -281,6 +307,15 @@ install_pkgs_zypper() {
         sudo zypper install -y "$p" >/dev/null 2>&1 || \
             warn "$p not available via zypper; will fall back to PyPI wheel."
     done
+    # Clipboard tool for "Copy share link" — the in-page clipboard API is
+    # unreliable in QtWebEngine on http:// origins, so the app shells out.
+    if [[ "$SESSION" == "wayland" ]]; then
+        sudo zypper install -y wl-clipboard >/dev/null 2>&1 || \
+            warn "wl-clipboard not available; copying links will offer a manual-copy dialog."
+    else
+        sudo zypper install -y xclip >/dev/null 2>&1 || \
+            warn "xclip not available; copying links will offer a manual-copy dialog."
+    fi
     if [[ "$SESSION" == "wayland" ]] && ! command -v wf-recorder &>/dev/null; then
         sudo zypper install -y wf-recorder >/dev/null 2>&1 || true
     fi
@@ -365,10 +400,20 @@ _gsr_build_from_source() {
     fi
     tmpdir=$(mktemp -d -t vice-gsr-XXXXXX)
     git clone --depth 1 --branch "$gsr_ref" "$GSR_REPO_URL" "$tmpdir" || { rm -rf "$tmpdir"; return 1; }
-    # Delegate to upstream's installer: it owns the meson+ninja recipe, the
-    # SUID-root setup for KMS capture, and tracks build-flag changes.
-    ( cd "$tmpdir" && sudo ./install.sh ) || { rm -rf "$tmpdir"; return 1; }
-    rm -rf "$tmpdir"
+    # Build as the invoking user; only the install step needs root. Running
+    # upstream's deprecated install.sh under sudo built everything as root,
+    # which left a root-owned build tree in /tmp that the cleanup below
+    # could not delete (hundreds of "rm: Permission denied" lines, #84).
+    # These meson options match what upstream's installer used; meson's
+    # install scripts (run as root) handle the gsr-kms-server capability
+    # setup that KMS capture needs.
+    (
+        cd "$tmpdir" \
+        && meson setup build --prefix=/usr --buildtype=release -Dsystemd=true -Dstrip=true \
+        && ninja -C build \
+        && sudo meson install -C build
+    ) || { rm -rf "$tmpdir" 2>/dev/null || sudo rm -rf "$tmpdir"; return 1; }
+    rm -rf "$tmpdir" 2>/dev/null || sudo rm -rf "$tmpdir"
 }
 
 install_gpu_screen_recorder() {

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -31,6 +31,32 @@ class InstallScriptTests(unittest.TestCase):
         self.assertIn("dnf is not the right install path", script)
         self.assertLess(script.index("if is_rpm_ostree_system; then"), script.index("detect_package_manager()"))
 
+    def test_gsr_build_runs_as_user_with_sudo_only_for_install(self) -> None:
+        """Regression test for #84: building under sudo left a root-owned
+        tree in /tmp that cleanup could not delete."""
+        script = self.script
+
+        # The upstream installer (which runs everything as root) is gone.
+        self.assertNotIn("sudo ./install.sh", script)
+        # Build steps run unprivileged; only meson install is elevated.
+        self.assertIn("meson setup build", script)
+        self.assertNotIn("sudo meson setup", script)
+        self.assertNotIn("sudo ninja", script)
+        self.assertIn("sudo meson install -C build", script)
+        # Cleanup has a sudo fallback for any root-owned leftovers.
+        self.assertIn('rm -rf "$tmpdir" 2>/dev/null || sudo rm -rf "$tmpdir"', script)
+
+    def test_clipboard_tools_installed_per_session_type(self) -> None:
+        script = self.script
+
+        self.assertIn("wl-clipboard", script)
+        self.assertIn("xclip", script)
+        # Present in every package-manager branch.
+        for mgr in ("apt-get install -y wl-clipboard",
+                    "dnf install -y wl-clipboard",
+                    "zypper install -y wl-clipboard"):
+            self.assertIn(mgr, script)
+
     def test_apt_gsr_build_deps_include_upstream_required_headers(self) -> None:
         match = re.search(
             r"apt\)\s+sudo apt-get install -y (?P<packages>.*?) \|\| return 1",


### PR DESCRIPTION
### Root cause (#84)

The GSR source build ran upstream's deprecated `install.sh` under sudo, compiling everything as root inside the mktemp dir. The user-level `rm -rf` cleanup afterwards sprayed hundreds of `rm: Permission non accordée` lines (the reporter's log), making a successful install look broken.

### Changes

- The build now runs `meson setup` and `ninja` as the invoking user with the exact options upstream's installer used (`--prefix=/usr --buildtype=release -Dsystemd=true -Dstrip=true`); only `meson install -C build` is elevated. Verified against upstream GSR 5.13.3: its install.sh is just meson+ninja, and the `gsr-kms-server` setcap happens via `meson.add_install_script` during the (root) install step, so KMS capture still works without a password prompt.
- Cleanup falls back to `sudo rm -rf` quietly if anything root-owned remains.
- Every package-manager branch installs a clipboard tool (wl-clipboard on Wayland, xclip on X11). "Could not copy link" reports (#76, #78) traced to neither tool existing; the app shells out for clipboard access because QtWebEngine's in-page clipboard API is unreliable on http:// origins.

### Verification

- `python -m unittest discover tests/` — 93 tests pass on this branch (new static assertions: no `sudo ./install.sh`, unprivileged build steps, sudo only on `meson install`, clipboard packages in all four branches). `bash -n install.sh` passes.
- Reasoned, not run end-to-end here: full installs on Debian/Fedora/openSUSE. The meson option equivalence was verified directly against the pinned upstream tag.

Closes #84. Together with the app branch, closes #76.
