### PR TITLE
Add container option, separate audio tracks, and game-tagged clip names

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,9 +154,11 @@ fps             = 60
 display         = "DP-1"  # optional; omit to use the backend default display
 encoder         = "auto"  # auto | h264_nvenc | hevc_nvenc | h264_vaapi | hevc_vaapi | libx264 | libx265
 backend         = "auto"  # auto | gsr | wf-recorder | ffmpeg
+container       = "mp4"   # mp4 | mkv (mkv is crash-safe; Discord embeds need mp4)
 capture_audio   = true
 capture_microphone = false
 gsr_audio_source = "default_output" # default_output | device:name | app:name | app-inverse:name
+audio_tracks    = []      # separate tracks instead of a mix, e.g. ["default_output", "default_input", "app:Discord"]
 gsr_args        = ""      # extra gpu-screen-recorder flags, e.g. "-k hevc -bm cbr -q 20000"
 
 [hotkeys]
@@ -172,6 +174,7 @@ duration = 120
 
 [output]
 directory = "~/Videos/Vice"
+tag_clips_with_game = true  # Vice_Clip_4_Overwatch-2.mp4 when a known game is focused
 
 [sharing]
 enabled           = true
@@ -187,6 +190,8 @@ client_id_override = ""     # leave blank to use Vice's default Discord app
 ```
 
 `recording.gsr_args` supports environment/tilde expansion and a `{default_sink_monitor}` placeholder for desktop-audio capture. `recording.gsr_audio_source` is used by the default gpu-screen-recorder backend.
+
+`recording.audio_tracks` records each listed source as its own audio track (gpu-screen-recorder backend). Track order matches the list; browsers and Discord play only the first track, while video editors see all of them. Useful for keeping game, voice chat, and microphone separable, like `["default_output", "default_input", "app:Discord"]`. The `container` and `audio_tracks` options apply to the gpu-screen-recorder backend; wf-recorder/ffmpeg clips stay single-track MP4.
 
 ---
 

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -1,0 +1,154 @@
+import asyncio
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from vice.media import cleanup_temp_files, get_duration, probe_media
+
+FFMPEG = shutil.which("ffmpeg")
+FFPROBE = shutil.which("ffprobe")
+
+
+def _make_video(path: Path, *, fragmented: bool, duration: float = 1.0) -> None:
+    cmd = [
+        FFMPEG, "-hide_banner", "-loglevel", "error",
+        "-f", "lavfi", "-i", f"testsrc=duration={duration}:size=128x72:rate=10",
+    ]
+    if fragmented:
+        # Fragmented MP4 has no per-stream duration tags — this is what
+        # gpu-screen-recorder writes for replay clips.
+        cmd += ["-movflags", "frag_keyframe+empty_moov"]
+    cmd += ["-y", str(path)]
+    subprocess.run(cmd, check=True, timeout=60)
+
+
+@unittest.skipUnless(FFMPEG and FFPROBE, "ffmpeg/ffprobe not installed")
+class ProbeMediaTests(unittest.IsolatedAsyncioTestCase):
+    async def test_probe_reads_duration_of_regular_mp4(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            clip = Path(tmp) / "clip.mp4"
+            _make_video(clip, fragmented=False)
+            meta = await probe_media(clip)
+
+        self.assertIsNotNone(meta)
+        self.assertEqual(meta["width"], 128)
+        self.assertEqual(meta["height"], 72)
+        self.assertGreater(meta["duration"], 0.5)
+
+    async def test_probe_reads_duration_of_fragmented_mp4(self) -> None:
+        """Regression test for #81: fragmented MP4 has no stream duration
+        tag, and probing only the stream field reported 0 for healthy
+        clips — triggering bogus timeouts and a destructive remux."""
+        with tempfile.TemporaryDirectory() as tmp:
+            clip = Path(tmp) / "clip.mp4"
+            _make_video(clip, fragmented=True)
+            meta = await probe_media(clip)
+            duration = await get_duration(clip)
+
+        self.assertIsNotNone(meta)
+        self.assertGreater(meta["duration"], 0.5)
+        self.assertGreater(duration, 0.5)
+
+    async def test_probe_returns_none_for_garbage(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            junk = Path(tmp) / "junk.mp4"
+            junk.write_bytes(b"this is not a video")
+            meta = await probe_media(junk)
+
+        self.assertIsNone(meta)
+
+
+class CleanupTempFilesTests(unittest.TestCase):
+    def test_removes_edit_leftovers_and_keeps_clips(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            keep = out / "Vice_Clip_1.mp4"
+            keep.write_bytes(b"clip")
+            stale = [
+                out / "Vice_Clip_1.trim.mp4",
+                out / "Vice_Clip_2.wm.mp4",
+                out / "Replay_x.mp4.fix.mp4",
+            ]
+            for p in stale:
+                p.write_bytes(b"partial")
+
+            cleanup_temp_files(out)
+
+            self.assertTrue(keep.exists())
+            for p in stale:
+                self.assertFalse(p.exists(), p.name)
+
+    def test_missing_directory_is_a_noop(self) -> None:
+        cleanup_temp_files(Path("/nonexistent/vice-test-dir"))
+
+
+class RemuxGuardTests(unittest.IsolatedAsyncioTestCase):
+    """_remux_moov must never replace a clip with a worse file."""
+
+    async def test_remux_keeps_original_when_output_is_truncated(self) -> None:
+        from vice.share import _remux_moov
+
+        with tempfile.TemporaryDirectory() as tmp:
+            original = Path(tmp) / "clip.mp4"
+            original.write_bytes(b"x" * 10_000)
+
+            class _Proc:
+                returncode = 0
+
+                async def wait(self):
+                    return 0
+
+            async def _fake_exec(*cmd, **_kwargs):
+                # ffmpeg "succeeds" but emits a near-empty file, like the
+                # 0.02 s remuxes reported in #81.
+                Path(cmd[-1]).write_bytes(b"tiny")
+                return _Proc()
+
+            async def _fake_probe(_: Path):
+                return {"width": 128, "height": 72, "duration": 0.02}
+
+            with mock.patch(
+                "vice.share.asyncio.create_subprocess_exec", new=_fake_exec
+            ):
+                with mock.patch("vice.share.probe_media", new=_fake_probe):
+                    replaced = await _remux_moov(original)
+
+            self.assertFalse(replaced)
+            self.assertEqual(original.read_bytes(), b"x" * 10_000)
+            self.assertEqual(list(Path(tmp).glob("*.fix.mp4")), [])
+
+    async def test_remux_replaces_original_when_output_is_sane(self) -> None:
+        from vice.share import _remux_moov
+
+        with tempfile.TemporaryDirectory() as tmp:
+            original = Path(tmp) / "clip.mp4"
+            original.write_bytes(b"x" * 10_000)
+
+            class _Proc:
+                returncode = 0
+
+                async def wait(self):
+                    return 0
+
+            async def _fake_exec(*cmd, **_kwargs):
+                Path(cmd[-1]).write_bytes(b"y" * 9_800)
+                return _Proc()
+
+            async def _fake_probe(_: Path):
+                return {"width": 128, "height": 72, "duration": 14.9}
+
+            with mock.patch(
+                "vice.share.asyncio.create_subprocess_exec", new=_fake_exec
+            ):
+                with mock.patch("vice.share.probe_media", new=_fake_probe):
+                    replaced = await _remux_moov(original)
+
+            self.assertTrue(replaced)
+            self.assertEqual(original.read_bytes(), b"y" * 9_800)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runtime_and_recorder.py
+++ b/tests/test_runtime_and_recorder.py
@@ -716,6 +716,39 @@ class RecorderStabilizationTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(saved.name, "Vice_Clip_1.mp4")
 
 
+class ClipNamingTests(unittest.IsolatedAsyncioTestCase):
+    def test_next_clip_path_counts_tagged_and_mkv_clips(self) -> None:
+        from vice.recorder import _next_clip_path
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            (out / "Vice_Clip_1.mp4").write_bytes(b"x")
+            (out / "Vice_Clip_2_Overwatch-2.mkv").write_bytes(b"x")
+
+            untagged = _next_clip_path(out)
+            tagged = _next_clip_path(out, ext="mkv", tag="Deep-Rock-Galactic")
+
+        self.assertEqual(untagged.name, "Vice_Clip_3.mp4")
+        self.assertEqual(tagged.name, "Vice_Clip_3_Deep-Rock-Galactic.mkv")
+
+    async def test_clip_tag_is_sanitized_for_filenames(self) -> None:
+        recorder = GSRRecorder(
+            Config(output=OutputConfig(directory="/tmp/vice-test"))
+        )
+        recorder.clip_tag_cb = lambda: "Overwatch 2: Beta!"
+
+        self.assertEqual(await recorder._clip_tag(), "Overwatch-2-Beta")
+
+        recorder.clip_tag_cb = lambda: None
+        self.assertIsNone(await recorder._clip_tag())
+
+        def _boom() -> str:
+            raise RuntimeError("window detection failed")
+
+        recorder.clip_tag_cb = _boom
+        self.assertIsNone(await recorder._clip_tag())
+
+
 class RecorderAudioCommandTests(unittest.TestCase):
     def test_list_display_options_parses_gsr_capture_options(self) -> None:
         gsr_out = "\n".join(
@@ -863,6 +896,48 @@ class RecorderAudioCommandTests(unittest.TestCase):
         cmd = GSRRecorder._gsr_session_cmd(Path("/tmp/vice-test/out.mp4"), rc)
 
         self.assertEqual(cmd[cmd.index("-s") + 1], "1920x1080")
+
+    def test_gsr_build_cmd_uses_configured_container(self) -> None:
+        recorder = GSRRecorder(
+            Config(
+                output=OutputConfig(directory="/tmp/vice-test"),
+                recording=RecordingConfig(container="mkv"),
+            )
+        )
+
+        cmd = recorder._build_cmd()
+
+        self.assertEqual(cmd[cmd.index("-c") + 1], "mkv")
+
+    def test_gsr_build_cmd_falls_back_to_mp4_for_unknown_container(self) -> None:
+        recorder = GSRRecorder(
+            Config(
+                output=OutputConfig(directory="/tmp/vice-test"),
+                recording=RecordingConfig(container="avi"),
+            )
+        )
+
+        cmd = recorder._build_cmd()
+
+        self.assertEqual(cmd[cmd.index("-c") + 1], "mp4")
+
+    def test_gsr_build_cmd_emits_one_audio_flag_per_track(self) -> None:
+        recorder = GSRRecorder(
+            Config(
+                output=OutputConfig(directory="/tmp/vice-test"),
+                recording=RecordingConfig(
+                    capture_audio=True,
+                    audio_tracks=["default_output", "default_input", "app:Discord"],
+                ),
+            )
+        )
+
+        cmd = recorder._build_cmd()
+
+        audio_values = [cmd[i + 1] for i, a in enumerate(cmd) if a == "-a"]
+        self.assertEqual(
+            audio_values, ["default_output", "default_input", "app:Discord"]
+        )
 
     def test_gsr_build_cmd_maps_hevc_encoder_to_gsr_codec(self) -> None:
         recorder = GSRRecorder(

--- a/tests/test_runtime_and_recorder.py
+++ b/tests/test_runtime_and_recorder.py
@@ -584,7 +584,8 @@ class RecorderStabilizationTests(unittest.IsolatedAsyncioTestCase):
                     clip,
                     stable_polls=3,
                     poll_interval=0.03,
-                    timeout=1.0,
+                    inactivity_timeout=1.0,
+                    max_wait=5.0,
                 )
             elapsed = time.monotonic() - start
             await writer
@@ -592,6 +593,93 @@ class RecorderStabilizationTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(ready)
         self.assertGreaterEqual(elapsed, 0.18)
         self.assertEqual(observed[-1], b"abc")
+
+    async def test_wait_for_finalized_clip_gives_up_after_write_inactivity(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            clip = Path(tmp) / "raw.mp4"
+            clip.write_bytes(b"not a video")
+
+            async def _zero_duration(_: Path) -> float:
+                return 0.0
+
+            start = time.monotonic()
+            with mock.patch("vice.recorder._get_duration", new=_zero_duration):
+                ready = await _wait_for_finalized_clip(
+                    clip,
+                    stable_polls=2,
+                    poll_interval=0.02,
+                    inactivity_timeout=0.15,
+                    max_wait=5.0,
+                )
+            elapsed = time.monotonic() - start
+
+        self.assertFalse(ready)
+        self.assertLess(elapsed, 2.0)
+
+    async def test_wait_for_finalized_clip_tolerates_slow_writes(self) -> None:
+        """A file that keeps growing must not be abandoned, even when the
+        total write time exceeds the inactivity timeout."""
+        with tempfile.TemporaryDirectory() as tmp:
+            clip = Path(tmp) / "raw.mp4"
+
+            async def _writer() -> None:
+                # Total write time (0.8 s) far exceeds the inactivity
+                # timeout (0.3 s); only the gaps between writes count.
+                data = b""
+                for _ in range(16):
+                    data += b"x" * 10
+                    clip.write_bytes(data)
+                    await asyncio.sleep(0.05)
+
+            durations = iter([0.0] * 2)
+
+            async def _fake_duration(_: Path) -> float:
+                return next(durations, 30.0)
+
+            writer = asyncio.create_task(_writer())
+            with mock.patch("vice.recorder._get_duration", new=_fake_duration):
+                ready = await _wait_for_finalized_clip(
+                    clip,
+                    stable_polls=2,
+                    poll_interval=0.03,
+                    inactivity_timeout=0.3,
+                    max_wait=5.0,
+                )
+            await writer
+
+        self.assertTrue(ready)
+
+    async def test_trim_copy_command_avoids_negative_timestamps(self) -> None:
+        captured: dict = {}
+
+        async def _fake_duration(_: Path) -> float:
+            return 100.0
+
+        class _Proc:
+            returncode = 0
+
+            async def communicate(self):
+                return b"", b""
+
+        async def _fake_exec(*cmd, **_kwargs):
+            captured["cmd"] = list(cmd)
+            return _Proc()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            clip = Path(tmp) / "clip.mp4"
+            clip.write_bytes(b"clip")
+            with mock.patch("vice.recorder._get_duration", new=_fake_duration):
+                with mock.patch(
+                    "vice.recorder.asyncio.create_subprocess_exec", new=_fake_exec
+                ):
+                    from vice.recorder import _trim_to_last_n_seconds
+
+                    await _trim_to_last_n_seconds(clip, 30)
+
+        cmd = captured["cmd"]
+        self.assertIn("-avoid_negative_ts", cmd)
+        self.assertEqual(cmd[cmd.index("-avoid_negative_ts") + 1], "make_zero")
+        self.assertIn("copy", cmd)
 
     async def test_gsr_save_clip_waits_for_finalized_file_before_trim(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -728,6 +816,53 @@ class RecorderAudioCommandTests(unittest.TestCase):
         cmd = recorder._build_cmd()
 
         self.assertEqual(cmd[cmd.index("-a") + 1], "device:game.monitor|default_input")
+
+    def test_gsr_build_cmd_passes_configured_resolution(self) -> None:
+        recorder = GSRRecorder(
+            Config(
+                output=OutputConfig(directory="/tmp/vice-test"),
+                recording=RecordingConfig(resolution="1280x720"),
+            )
+        )
+
+        cmd = recorder._build_cmd()
+
+        self.assertEqual(cmd[cmd.index("-s") + 1], "1280x720")
+
+    def test_gsr_build_cmd_ignores_invalid_resolution(self) -> None:
+        recorder = GSRRecorder(
+            Config(
+                output=OutputConfig(directory="/tmp/vice-test"),
+                recording=RecordingConfig(resolution="720p"),
+            )
+        )
+
+        cmd = recorder._build_cmd()
+
+        self.assertNotIn("-s", cmd)
+
+    def test_gsr_build_cmd_keeps_user_resolution_override(self) -> None:
+        recorder = GSRRecorder(
+            Config(
+                output=OutputConfig(directory="/tmp/vice-test"),
+                recording=RecordingConfig(
+                    resolution="1280x720",
+                    gsr_args="-s 640x360",
+                ),
+            )
+        )
+
+        cmd = recorder._build_cmd()
+
+        self.assertEqual(cmd.count("-s"), 1)
+        self.assertEqual(cmd[cmd.index("-s") + 1], "640x360")
+
+    def test_gsr_session_cmd_passes_configured_resolution(self) -> None:
+        rc = RecordingConfig(resolution="1920x1080")
+
+        cmd = GSRRecorder._gsr_session_cmd(Path("/tmp/vice-test/out.mp4"), rc)
+
+        self.assertEqual(cmd[cmd.index("-s") + 1], "1920x1080")
 
     def test_gsr_build_cmd_maps_hevc_encoder_to_gsr_codec(self) -> None:
         recorder = GSRRecorder(

--- a/tests/test_share_server.py
+++ b/tests/test_share_server.py
@@ -156,6 +156,21 @@ class ShareServerSecurityTests(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(resp.status, 200)
             self.assertEqual(resp.headers.get("Content-Type"), "image/jpeg")
 
+    async def test_mkv_clips_are_listed_and_served(self) -> None:
+        mkv = self.output_dir / "mkv_clip.mkv"
+        mkv.write_bytes(b"not-a-real-mkv")
+        self.server.add_clip(mkv)
+
+        local_base = self.server.local_base_url()
+        async with self.client.get(f"{local_base}/api/clips") as resp:
+            payload = await resp.json()
+        slugs = {c["slug"] for c in payload["clips"]}
+        self.assertIn("mkv_clip", slugs)
+
+        public_base = f"http://127.0.0.1:{self.public_port}"
+        async with self.client.get(f"{public_base}/v/mkv_clip") as resp:
+            self.assertEqual(resp.status, 200)
+
     async def test_public_server_blocks_privileged_routes_and_mutation(self) -> None:
         public_base = f"http://127.0.0.1:{self.public_port}"
 

--- a/vice/config.py
+++ b/vice/config.py
@@ -60,6 +60,15 @@ class RecordingConfig:
     # gpu-screen-recorder desktop audio source. Examples:
     # default_output, device:alsa_output.pci.monitor, app:firefox, app-inverse:firefox
     gsr_audio_source: str = "default_output"
+    # Clip container: "mp4" or "mkv". mkv survives crashes better and is the
+    # base for multi-track audio, but Discord/browser embeds need mp4.
+    # Applies to the gpu-screen-recorder backend.
+    container: str = "mp4"
+    # Record these audio sources as separate tracks instead of mixing them
+    # (gpu-screen-recorder backend). Each entry is one track, same ids as
+    # gsr_audio_source. Example: ["default_output", "default_input",
+    # "app:Discord"]. Empty = mix into a single track (the default).
+    audio_tracks: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -83,6 +92,10 @@ class HotkeyConfig:
 class OutputConfig:
     directory: str = str(actual_home_dir() / "Videos" / "Vice")
     filename_format: str = "vice_%Y%m%d_%H%M%S.mp4"
+    # Append the detected game to clip filenames (Vice_Clip_4_Overwatch-2.mp4).
+    # Uses the same curated games list as Discord Rich Presence; clips save
+    # untagged when no known game is focused or the compositor is unsupported.
+    tag_clips_with_game: bool = True
 
 
 @dataclass

--- a/vice/main.py
+++ b/vice/main.py
@@ -44,6 +44,7 @@ from .config import (
     save as save_config,
 )
 from .hotkey import HotkeyListener, can_access_hotkeys, list_available_keys
+from .media import cleanup_temp_files
 from .recorder import create_recorder
 from .runtime import (
     actual_home_dir,
@@ -126,7 +127,11 @@ class ViceDaemon:
 
     async def run(self) -> None:
         Path("/tmp/vice").mkdir(parents=True, exist_ok=True)
-        resolve_path(self.cfg.output.directory).mkdir(parents=True, exist_ok=True)
+        out_dir = resolve_path(self.cfg.output.directory)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        # Remove half-written temp files (trim/watermark/remux) from a
+        # previous run that was interrupted mid-edit.
+        cleanup_temp_files(out_dir)
 
         # Share server (web UI + REST API + WebSocket)
         if self.cfg.sharing.enabled:

--- a/vice/main.py
+++ b/vice/main.py
@@ -150,6 +150,9 @@ class ViceDaemon:
 
         # Recorder callback — fires for both normal clips and session clips
         self.recorder.on_clip_saved(self._on_clip_saved)
+        # Tag clip filenames with the focused game (curated list, same
+        # detection as Discord Rich Presence).
+        self.recorder.clip_tag_cb = self._clip_game_tag
 
         # Hotkeys
         self._bind_hotkeys()
@@ -441,6 +444,23 @@ class ViceDaemon:
             self._discord_client_id = None
             self._discord_current_game = None
             self._discord_last_activity = None
+
+    def _clip_game_tag(self) -> Optional[str]:
+        """Focused game name for clip filename tagging, or None.
+
+        Sync (the recorder runs it in a thread — window detection shells
+        out to the compositor). Detection only matches the curated games
+        list, so arbitrary window titles never end up in filenames.
+        """
+        if not getattr(self.cfg.output, "tag_clips_with_game", False):
+            return None
+        try:
+            from .active_window import get_active_window
+            win = get_active_window()
+            return self._match_game(win) if win else None
+        except Exception:
+            log.debug("Game detection for clip tagging failed", exc_info=True)
+            return None
 
     def _match_game(self, win: dict) -> Optional[str]:
         proc = (win.get("process") or "").lower()

--- a/vice/media.py
+++ b/vice/media.py
@@ -19,7 +19,8 @@ log = logging.getLogger("vice.media")
 # Suffix patterns for temp files written during in-place edits
 # (trim / watermark / remux). Leftovers mean a previous run was
 # interrupted mid-edit; they are safe to delete at daemon startup.
-TEMP_FILE_GLOBS = ("*.trim.mp4", "*.wm.mp4", "*.fix.mp4")
+TEMP_FILE_GLOBS = ("*.trim.mp4", "*.wm.mp4", "*.fix.mp4",
+                   "*.trim.mkv", "*.wm.mkv", "*.fix.mkv")
 
 
 async def probe_media(path: Path) -> Optional[dict]:

--- a/vice/media.py
+++ b/vice/media.py
@@ -1,0 +1,93 @@
+"""Shared ffprobe helpers for clip files.
+
+Used by both the recorder (clip finalization, trimming) and the share
+server (metadata, thumbnails). Kept in one place so duration handling
+behaves identically everywhere.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import math
+from pathlib import Path
+from typing import Optional
+
+log = logging.getLogger("vice.media")
+
+# Suffix patterns for temp files written during in-place edits
+# (trim / watermark / remux). Leftovers mean a previous run was
+# interrupted mid-edit; they are safe to delete at daemon startup.
+TEMP_FILE_GLOBS = ("*.trim.mp4", "*.wm.mp4", "*.fix.mp4")
+
+
+async def probe_media(path: Path) -> Optional[dict]:
+    """Probe *path* with ffprobe.
+
+    Returns ``{"width", "height", "duration"}`` or ``None`` when ffprobe
+    fails or the file has no video stream.
+
+    Duration prefers the container (format) value over the stream value:
+    fragmented MP4 — which gpu-screen-recorder writes for replay clips —
+    has no per-stream duration tag, so reading only the stream field
+    reports 0 for perfectly healthy files.
+    """
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "ffprobe", "-v", "quiet", "-print_format", "json",
+            "-show_format", "-show_streams", str(path),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=15)
+        data = json.loads(stdout)
+    except FileNotFoundError:
+        log.error("ffprobe not found — install ffmpeg to read clip metadata")
+        return None
+    except Exception as exc:
+        log.debug("ffprobe failed for %s: %s", path.name, exc)
+        return None
+
+    video = next(
+        (s for s in data.get("streams", []) if s.get("codec_type") == "video"),
+        None,
+    )
+    if video is None:
+        return None
+
+    duration = _parse_duration(data.get("format", {}).get("duration"))
+    if duration <= 0:
+        duration = _parse_duration(video.get("duration"))
+    return {
+        "width": int(video.get("width") or 0),
+        "height": int(video.get("height") or 0),
+        "duration": duration,
+    }
+
+
+def _parse_duration(raw) -> float:
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return 0.0
+    return value if math.isfinite(value) and value > 0 else 0.0
+
+
+async def get_duration(path: Path) -> float:
+    """Duration of *path* in seconds, or 0.0 when it cannot be read."""
+    meta = await probe_media(path)
+    return meta["duration"] if meta else 0.0
+
+
+def cleanup_temp_files(directory: Path) -> None:
+    """Delete leftover in-place-edit temp files from interrupted runs."""
+    if not directory.is_dir():
+        return
+    for pattern in TEMP_FILE_GLOBS:
+        for stale in directory.glob(pattern):
+            try:
+                stale.unlink()
+                log.info("Removed stale temp file %s", stale.name)
+            except OSError as exc:
+                log.warning("Could not remove stale temp file %s: %s", stale, exc)

--- a/vice/recorder.py
+++ b/vice/recorder.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from typing import Callable, List, Optional
 
 from .config import Config
+from .media import get_duration as _get_duration
 from .runtime import recover_wayland_display, resolve_path
 
 log = logging.getLogger("vice.recorder")
@@ -191,6 +192,20 @@ def _gsr_codec_for_encoder(encoder: str) -> Optional[str]:
     if encoder in {"hevc_nvenc", "hevc_vaapi", "libx265"}:
         return "hevc"
     return None
+
+
+def _gsr_resolution_args(rc, extra: list[str]) -> list[str]:
+    """GSR `-s WxH` flag for the configured output resolution, if any."""
+    resolution = (getattr(rc, "resolution", None) or "").strip()
+    if not resolution or _gsr_has_any_flag(extra, "-s"):
+        return []
+    if not re.fullmatch(r"\d+x\d+", resolution):
+        log.warning(
+            "Ignoring recording.resolution=%r — expected WIDTHxHEIGHT (e.g. 1920x1080)",
+            resolution,
+        )
+        return []
+    return ["-s", resolution]
 
 
 def _gsr_sanitize_args(args: list[str], blocked_flags: set[str]) -> list[str]:
@@ -975,6 +990,7 @@ class Recorder(ABC):
             cmd += ["-w", _gsr_capture_target(rc)]
         if not _gsr_has_any_flag(extra, "-f"):
             cmd += ["-f", str(rc.fps)]
+        cmd += _gsr_resolution_args(rc, extra)
         if not _gsr_has_any_flag(extra, "-c"):
             cmd += ["-c", "mp4"]
         codec = _gsr_codec_for_encoder(rc.encoder)
@@ -1028,23 +1044,6 @@ def _next_session_path(out_dir: Path) -> Path:
     return out_dir / f"Vice_Session_{max_n + 1}.mp4"
 
 
-async def _get_duration(path: Path) -> float:
-    """Return the duration of a video file in seconds via ffprobe."""
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            "ffprobe", "-v", "quiet", "-print_format", "json", "-show_streams", str(path),
-            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.DEVNULL,
-        )
-        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=15)
-        import json
-        for s in json.loads(stdout).get("streams", []):
-            if s.get("codec_type") == "video":
-                return float(s.get("duration", 0))
-    except Exception:
-        pass
-    return 0.0
-
-
 async def _trim_to_last_n_seconds(path: Path, seconds: int) -> Path:
     """Trim a clip to its last `seconds` seconds in-place. Returns the path."""
     total = await _get_duration(path)
@@ -1057,7 +1056,9 @@ async def _trim_to_last_n_seconds(path: Path, seconds: int) -> Path:
         return [
             "ffmpeg", "-hide_banner", "-loglevel", "error",
             "-ss", str(start), "-i", str(path),
-            "-t", str(seconds), "-c", "copy", "-movflags", "+faststart",
+            "-t", str(seconds), "-c", "copy",
+            "-avoid_negative_ts", "make_zero",
+            "-movflags", "+faststart",
             "-y", str(tmp),
         ]
 
@@ -1107,11 +1108,21 @@ async def _wait_for_finalized_clip(
     *,
     stable_polls: int = 3,
     poll_interval: float = 0.25,
-    timeout: float = 10.0,
+    inactivity_timeout: float = 15.0,
+    max_wait: float = 600.0,
 ) -> bool:
-    """Wait until a replay clip stops changing and ffprobe can read it."""
-    deadline = time.monotonic() + timeout
+    """Wait until a replay clip stops changing and ffprobe can read it.
+
+    The timeout is based on write inactivity, not total elapsed time:
+    flushing a long replay buffer can legitimately take minutes on slow
+    storage, and a fixed deadline used to abandon clips that were still
+    being written (and would have finished fine). We only give up when
+    the file has stopped growing for `inactivity_timeout` seconds and
+    still cannot be probed, or after `max_wait` as a hard safety cap.
+    """
+    deadline = time.monotonic() + max_wait
     last_sig: tuple[int, int] | None = None
+    last_change = time.monotonic()
     stable = 0
 
     while time.monotonic() < deadline:
@@ -1119,17 +1130,22 @@ async def _wait_for_finalized_clip(
             st = path.stat()
             sig = (st.st_size, st.st_mtime_ns)
         except OSError:
-            await asyncio.sleep(poll_interval)
-            continue
+            sig = None
 
-        if sig[0] > 0 and sig == last_sig:
+        if sig != last_sig:
+            stable = 0
+            last_sig = sig
+            last_change = time.monotonic()
+        elif sig is not None and sig[0] > 0:
             stable += 1
         else:
             stable = 0
-            last_sig = sig
 
         if stable >= stable_polls and await _get_duration(path) > 0:
             return True
+
+        if time.monotonic() - last_change > inactivity_timeout:
+            return False
 
         await asyncio.sleep(poll_interval)
 
@@ -1209,6 +1225,8 @@ class GSRRecorder(Recorder):
 
         if not _gsr_has_any_flag(extra, "-f"):
             cmd += ["-f", str(rc.fps)]
+
+        cmd += _gsr_resolution_args(rc, extra)
 
         if not _gsr_has_any_flag(extra, "-r"):
             cmd += ["-r", str(rc.buffer_duration)]
@@ -1298,7 +1316,8 @@ class GSRRecorder(Recorder):
             log.error("GSR process not found")
             return None
 
-        # Wait for the new file to appear and finish writing.
+        # Wait for the new file to appear (GSR creates it almost immediately
+        # after SIGUSR1), then wait for GSR to finish writing it.
         deadline = time.monotonic() + 20
         while time.monotonic() < deadline:
             await asyncio.sleep(0.25)
@@ -1310,9 +1329,12 @@ class GSRRecorder(Recorder):
                     key=lambda p: p.stat().st_mtime,
                 )
                 self._seen_files = current
-                remaining = max(0.5, deadline - time.monotonic())
-                if not await _wait_for_finalized_clip(newest, timeout=remaining):
-                    log.error("Timed out waiting for GSR clip to finish writing: %s", newest)
+                if not await _wait_for_finalized_clip(newest):
+                    log.error(
+                        "GSR clip %s stopped being written but is unreadable — "
+                        "leaving the file in place for inspection",
+                        newest,
+                    )
                     return None
                 # Rename GSR's auto-generated filename to sequential Vice_Clip_N name.
                 seq_path = _next_clip_path(self._out_dir)

--- a/vice/recorder.py
+++ b/vice/recorder.py
@@ -194,6 +194,35 @@ def _gsr_codec_for_encoder(encoder: str) -> Optional[str]:
     return None
 
 
+def _container(rc) -> str:
+    """Validated clip container ("mp4" or "mkv")."""
+    value = (getattr(rc, "container", "") or "mp4").strip().lower()
+    if value not in {"mp4", "mkv"}:
+        log.warning("Unknown recording.container=%r — using mp4", value)
+        return "mp4"
+    return value
+
+
+def _gsr_audio_args(rc) -> list[str]:
+    """GSR audio flags: one -a per configured track, or one mixed input.
+
+    gpu-screen-recorder records each -a flag as its own audio track;
+    sources joined with "|" inside one flag are mixed together.
+    """
+    tracks = [
+        str(t).strip()
+        for t in (getattr(rc, "audio_tracks", None) or [])
+        if str(t).strip()
+    ]
+    if tracks:
+        args: list[str] = []
+        for track in tracks:
+            args += ["-a", track]
+        return args
+    merged = _gsr_audio_input(rc)
+    return ["-a", merged] if merged else []
+
+
 def _gsr_resolution_args(rc, extra: list[str]) -> list[str]:
     """GSR `-s WxH` flag for the configured output resolution, if any."""
     resolution = (getattr(rc, "resolution", None) or "").strip()
@@ -804,6 +833,9 @@ class Recorder(ABC):
         self.cfg = cfg
         self._running = False
         self._clip_callbacks: list[Callable[[Path], None]] = []
+        # Optional sync callback returning the focused game's name (or None);
+        # used to tag clip filenames. Runs in a thread (it shells out).
+        self.clip_tag_cb: Optional[Callable[[], Optional[str]]] = None
         # Session recording state (shared across all backends)
         self._session_active = False
         self._session_proc: Optional[asyncio.subprocess.Process] = None
@@ -814,6 +846,20 @@ class Recorder(ABC):
     def on_clip_saved(self, cb: Callable[[Path], None]) -> None:
         """Register a callback invoked with the clip Path once it's ready."""
         self._clip_callbacks.append(cb)
+
+    async def _clip_tag(self) -> Optional[str]:
+        """Sanitized filename tag for the clip being saved, or None."""
+        if not self.clip_tag_cb:
+            return None
+        try:
+            tag = await asyncio.to_thread(self.clip_tag_cb)
+        except Exception:
+            log.exception("Clip tag callback raised")
+            return None
+        if not tag:
+            return None
+        tag = re.sub(r"[^A-Za-z0-9]+", "-", tag).strip("-")
+        return tag[:48] or None
 
     def _emit(self, path: Path) -> None:
         for cb in self._clip_callbacks:
@@ -996,9 +1042,8 @@ class Recorder(ABC):
         codec = _gsr_codec_for_encoder(rc.encoder)
         if codec and not _gsr_has_any_flag(extra, "-k"):
             cmd += ["-k", codec]
-        audio_input = _gsr_audio_input(rc)
-        if audio_input and not _gsr_has_any_flag(extra, "-a"):
-            cmd += ["-a", audio_input]
+        if not _gsr_has_any_flag(extra, "-a"):
+            cmd += _gsr_audio_args(rc)
 
         cmd += extra
         cmd += ["-o", str(out_path)]
@@ -1020,28 +1065,34 @@ class Recorder(ABC):
 # Clip trimming helper (used by GSR backend)
 # ──────────────────────────────────────────────────────────────────────────────
 
-def _next_clip_path(out_dir: Path) -> Path:
-    """Return the next available Vice_Clip_N.mp4 path in out_dir."""
+def _media_file_names(out_dir: Path) -> set[str]:
+    """Names of clip media files (mp4 + mkv) currently in out_dir."""
+    return {f.name for f in out_dir.glob("*.mp4")} | {f.name for f in out_dir.glob("*.mkv")}
+
+
+def _next_numbered_path(out_dir: Path, stem: str, ext: str, tag: Optional[str] = None) -> Path:
+    """Next available <stem>_N[_Tag].<ext> path. Numbering counts every
+    container and tag variant so tagged clips never collide."""
     max_n = 0
-    for f in out_dir.glob("Vice_Clip_*.mp4"):
-        m = re.match(r"^Vice_Clip_(\d+)\.mp4$", f.name)
+    pattern = re.compile(rf"^{stem}_(\d+)(?:_.+)?\.(?:mp4|mkv)$")
+    for f in out_dir.glob(f"{stem}_*"):
+        m = pattern.match(f.name)
         if m:
             n = int(m.group(1))
             if n > max_n:
                 max_n = n
-    return out_dir / f"Vice_Clip_{max_n + 1}.mp4"
+    suffix = f"_{tag}" if tag else ""
+    return out_dir / f"{stem}_{max_n + 1}{suffix}.{ext}"
+
+
+def _next_clip_path(out_dir: Path, ext: str = "mp4", tag: Optional[str] = None) -> Path:
+    """Return the next available Vice_Clip_N[_Game].<ext> path in out_dir."""
+    return _next_numbered_path(out_dir, "Vice_Clip", ext, tag)
 
 
 def _next_session_path(out_dir: Path) -> Path:
     """Return the next available Vice_Session_N.mp4 path in out_dir."""
-    max_n = 0
-    for f in out_dir.glob("Vice_Session_*.mp4"):
-        m = re.match(r"^Vice_Session_(\d+)\.mp4$", f.name)
-        if m:
-            n = int(m.group(1))
-            if n > max_n:
-                max_n = n
-    return out_dir / f"Vice_Session_{max_n + 1}.mp4"
+    return _next_numbered_path(out_dir, "Vice_Session", "mp4")
 
 
 async def _trim_to_last_n_seconds(path: Path, seconds: int) -> Path:
@@ -1051,14 +1102,17 @@ async def _trim_to_last_n_seconds(path: Path, seconds: int) -> Path:
         return path  # already short enough
 
     start = total - seconds
-    tmp = path.with_suffix(".trim.mp4")
+    ext = path.suffix.lstrip(".") or "mp4"
+    tmp = path.with_suffix(f".trim.{ext}")
+    faststart = ["-movflags", "+faststart"] if ext == "mp4" else []
+
     def _copy_trim_cmd() -> list[str]:
         return [
             "ffmpeg", "-hide_banner", "-loglevel", "error",
             "-ss", str(start), "-i", str(path),
             "-t", str(seconds), "-c", "copy",
             "-avoid_negative_ts", "make_zero",
-            "-movflags", "+faststart",
+            *faststart,
             "-y", str(tmp),
         ]
 
@@ -1069,7 +1123,7 @@ async def _trim_to_last_n_seconds(path: Path, seconds: int) -> Path:
             "-t", str(seconds),
             "-c:v", "libx264", "-preset", "veryfast", "-crf", "23",
             "-c:a", "aac", "-b:a", "128k",
-            "-movflags", "+faststart",
+            *faststart,
             "-y", str(tmp),
         ]
 
@@ -1164,14 +1218,15 @@ _WATERMARK = (
 
 async def _apply_watermark(path: Path) -> None:
     """Burn the Vice watermark into *path* in-place (re-encodes with libx264)."""
-    tmp = path.with_suffix(".wm.mp4")
+    ext = path.suffix.lstrip(".") or "mp4"
+    tmp = path.with_suffix(f".wm.{ext}")
     cmd = [
         "ffmpeg", "-hide_banner", "-loglevel", "error",
         "-i", str(path),
         "-vf", _WATERMARK,
         "-c:v", "libx264", "-crf", "23", "-preset", "fast",
         "-c:a", "copy",
-        "-movflags", "+faststart",
+        *(["-movflags", "+faststart"] if ext == "mp4" else []),
         "-y", str(tmp),
     ]
     try:
@@ -1232,14 +1287,13 @@ class GSRRecorder(Recorder):
             cmd += ["-r", str(rc.buffer_duration)]
 
         if not _gsr_has_any_flag(extra, "-c"):
-            cmd += ["-c", "mp4"]
+            cmd += ["-c", _container(rc)]
         codec = _gsr_codec_for_encoder(rc.encoder)
         if codec and not _gsr_has_any_flag(extra, "-k"):
             cmd += ["-k", codec]
 
-        audio_input = _gsr_audio_input(rc)
-        if audio_input and not _gsr_has_any_flag(extra, "-a"):
-            cmd += ["-a", audio_input]
+        if not _gsr_has_any_flag(extra, "-a"):
+            cmd += _gsr_audio_args(rc)
 
         cmd += extra
 
@@ -1254,7 +1308,7 @@ class GSRRecorder(Recorder):
         self._running = True
 
         # Track existing files so we can detect newly saved clips
-        self._seen_files = {f.name for f in self._out_dir.glob("*.mp4")}
+        self._seen_files = _media_file_names(self._out_dir)
 
         self._proc = await asyncio.create_subprocess_exec(
             *cmd,
@@ -1321,7 +1375,7 @@ class GSRRecorder(Recorder):
         deadline = time.monotonic() + 20
         while time.monotonic() < deadline:
             await asyncio.sleep(0.25)
-            current = {f.name for f in self._out_dir.glob("*.mp4")}
+            current = _media_file_names(self._out_dir)
             new = current - self._seen_files
             if new:
                 newest = max(
@@ -1336,11 +1390,16 @@ class GSRRecorder(Recorder):
                         newest,
                     )
                     return None
-                # Rename GSR's auto-generated filename to sequential Vice_Clip_N name.
-                seq_path = _next_clip_path(self._out_dir)
+                # Rename GSR's auto-generated filename to a sequential
+                # Vice_Clip_N name, tagged with the focused game if known.
+                seq_path = _next_clip_path(
+                    self._out_dir,
+                    ext=newest.suffix.lstrip(".") or "mp4",
+                    tag=await self._clip_tag(),
+                )
                 newest.rename(seq_path)
                 newest = seq_path
-                self._seen_files = {f.name for f in self._out_dir.glob("*.mp4")}
+                self._seen_files = _media_file_names(self._out_dir)
                 # GSR saves the entire buffer; trim to the requested clip duration.
                 trimmed = await _trim_to_last_n_seconds(newest, clip_duration)
                 if self.cfg.recording.apply_watermark:
@@ -1610,7 +1669,7 @@ class SegmentRecorder(Recorder):
         first_ts = relevant[0][0]
         skip = max(0.0, clip_start - first_ts)
 
-        out_path = _next_clip_path(self._out_dir)
+        out_path = _next_clip_path(self._out_dir, tag=await self._clip_tag())
 
         ffmpeg_cmd = [
             "ffmpeg", "-hide_banner", "-loglevel", "warning",
@@ -1684,6 +1743,19 @@ def create_recorder(cfg: Config) -> Recorder:
     has_gsr = _has("gpu-screen-recorder")
     has_wf = _has("wf-recorder")
     has_ffmpeg = _has("ffmpeg")
+
+    if pref in ("wf-recorder", "ffmpeg"):
+        if _container(cfg.recording) != "mp4":
+            log.warning(
+                "recording.container=%s applies to the gpu-screen-recorder "
+                "backend; %s clips stay mp4",
+                _container(cfg.recording), pref,
+            )
+        if getattr(cfg.recording, "audio_tracks", None):
+            log.warning(
+                "recording.audio_tracks applies to the gpu-screen-recorder "
+                "backend; %s records a single mixed track", pref,
+            )
 
     if pref == "wf-recorder" and not on_wayland and not on_x11:
         # wf-recorder is the only backend whose selection actually depends on

--- a/vice/share.py
+++ b/vice/share.py
@@ -16,7 +16,6 @@ import asyncio
 import copy
 import json
 import logging
-import math
 import shutil
 import socket
 import subprocess
@@ -30,6 +29,7 @@ from importlib.resources import files as _pkg_files
 from aiohttp import WSMsgType, web
 
 from . import __version__
+from .media import probe_media
 from .recorder import list_display_options, list_gsr_audio_sources
 from .runtime import actual_home_dir, resolve_path
 
@@ -140,35 +140,19 @@ def _local_ip() -> str:
         return "127.0.0.1"
 
 
-async def _probe_once(path: Path) -> dict:
-    """Run a single ffprobe pass. Returns sensible defaults on failure."""
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            "ffprobe", "-v", "quiet", "-print_format", "json",
-            "-show_streams", str(path),
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.DEVNULL,
-        )
-        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=15)
-        data = json.loads(stdout)
-        for s in data.get("streams", []):
-            if s.get("codec_type") == "video":
-                return {
-                    "width":    s.get("width",    1920),
-                    "height":   s.get("height",   1080),
-                    "duration": float(s.get("duration", 0)),
-                }
-    except Exception:
-        pass
-    return {"width": 1920, "height": 1080, "duration": 0}
+_PROBE_DEFAULTS = {"width": 1920, "height": 1080, "duration": 0}
 
 
 async def _remux_moov(path: Path) -> bool:
-    """Rewrite `path` via `ffmpeg -c copy -movflags +faststart` in place.
+    """Try to recover `path` via `ffmpeg -c copy -movflags +faststart`.
 
-    Used to recover clips whose MP4 container is missing/corrupt (no moov
-    atom) — happens when the encoder was killed mid-finalize. Returns True
-    when the remuxed file successfully replaced the original.
+    Used for clips whose MP4 container is damaged (no moov atom) — happens
+    when the encoder was killed mid-finalize. The original file is only
+    replaced when the remuxed copy probes as a sane video of comparable
+    size; a remux that produces a near-empty file means the input was
+    *not* a simple moov-atom problem, and replacing would destroy data
+    (this used to truncate healthy clips to 0.02 s). Returns True when
+    the remuxed file replaced the original.
     """
     tmp = path.with_suffix(path.suffix + ".fix.mp4")
     try:
@@ -180,11 +164,26 @@ async def _remux_moov(path: Path) -> bool:
             stderr=asyncio.subprocess.DEVNULL,
         )
         await asyncio.wait_for(proc.wait(), timeout=60)
-        if proc.returncode == 0 and tmp.exists() and tmp.stat().st_size > 0:
-            tmp.replace(path)
-            return True
-    except Exception:
-        pass
+        if proc.returncode == 0 and tmp.exists():
+            remuxed = await probe_media(tmp)
+            orig_size = path.stat().st_size
+            if (
+                remuxed
+                and remuxed["duration"] > 0
+                and tmp.stat().st_size >= orig_size * 0.5
+            ):
+                tmp.replace(path)
+                return True
+            log.warning(
+                "Remux of %s produced an invalid or truncated file "
+                "(duration=%.2fs, %d → %d bytes) — keeping the original",
+                path.name,
+                remuxed["duration"] if remuxed else 0.0,
+                orig_size,
+                tmp.stat().st_size,
+            )
+    except Exception as exc:
+        log.warning("Remux of %s failed: %s", path.name, exc)
     try:
         tmp.unlink(missing_ok=True)
     except Exception:
@@ -195,19 +194,21 @@ async def _remux_moov(path: Path) -> bool:
 async def _ffprobe(path: Path) -> dict:
     """Return {"width", "height", "duration"} via ffprobe.
 
-    If the first probe yields a zero / non-finite duration the container
-    is probably missing its moov atom — try one remux + re-probe before
-    giving up.
+    If the file cannot be probed at all, its container is probably missing
+    the moov atom — try one (validated, non-destructive) remux + re-probe
+    before giving up.
     """
-    meta = await _probe_once(path)
-    dur = meta.get("duration", 0)
-    if isinstance(dur, (int, float)) and math.isfinite(dur) and dur > 0:
+    meta = await probe_media(path)
+    if meta and meta["duration"] > 0:
         return meta
-    log.warning("ffprobe reports duration=%s for %s — attempting moov remux", dur, path.name)
+    log.warning("ffprobe cannot read %s — attempting moov remux", path.name)
     if await _remux_moov(path):
-        meta = await _probe_once(path)
-        log.info("Remuxed %s — duration now %.2fs", path.name, meta.get("duration", 0))
-    return meta
+        meta = await probe_media(path)
+        log.info(
+            "Remuxed %s — duration now %.2fs",
+            path.name, meta["duration"] if meta else 0.0,
+        )
+    return meta or dict(_PROBE_DEFAULTS)
 
 
 async def _make_thumb(path: Path, duration: float = 0.0) -> Path:

--- a/vice/share.py
+++ b/vice/share.py
@@ -201,6 +201,10 @@ async def _ffprobe(path: Path) -> dict:
     meta = await probe_media(path)
     if meta and meta["duration"] > 0:
         return meta
+    if path.suffix.lower() != ".mp4":
+        # The remux below repairs MP4 moov atoms; other containers are
+        # served as-is.
+        return meta or dict(_PROBE_DEFAULTS)
     log.warning("ffprobe cannot read %s — attempting moov remux", path.name)
     if await _remux_moov(path):
         meta = await probe_media(path)
@@ -365,8 +369,9 @@ class ShareServer:
         # Pre-populate from output dir
         out_dir = resolve_path(self.cfg.output.directory)
         if out_dir.exists():
-            for mp4 in sorted(out_dir.glob("*.mp4"), key=lambda p: p.stat().st_mtime):
-                self._clips[mp4.stem] = mp4
+            media = list(out_dir.glob("*.mp4")) + list(out_dir.glob("*.mkv"))
+            for clip in sorted(media, key=lambda p: p.stat().st_mtime):
+                self._clips[clip.stem] = clip
 
         local_port = self.cfg.sharing.port
         public_port = self.cfg.sharing.public_port or (local_port + 1)
@@ -631,12 +636,14 @@ class ShareServer:
         if end <= start:
             return web.json_response({"ok": False, "error": "end must be after start"})
 
-        tmp = path.with_suffix(".trimming.mp4")
+        ext = path.suffix.lstrip(".") or "mp4"
+        tmp = path.with_suffix(f".trimming.{ext}")
         cmd = [
             "ffmpeg", "-hide_banner", "-loglevel", "error",
             "-ss", str(start), "-i", str(path),
             "-t",  str(end - start),
-            "-c",  "copy", "-movflags", "+faststart",
+            "-c",  "copy",
+            *(["-movflags", "+faststart"] if ext == "mp4" else []),
             "-y",  str(tmp),
         ]
         try:
@@ -671,12 +678,13 @@ class ShareServer:
         if not new_name:
             return web.json_response({"ok": False, "error": "name is required"})
 
-        # Sanitise — no path separators; always .mp4
+        # Sanitise — no path separators; keep the clip's own container.
+        ext = path.suffix.lower() or ".mp4"
         new_name = new_name.replace("/", "").replace("\\", "").replace("\0", "")
         if " " in new_name:
             return web.json_response({"ok": False, "error": "Clip name cannot contain spaces"})
-        if not new_name.lower().endswith(".mp4"):
-            new_name += ".mp4"
+        if not new_name.lower().endswith(ext):
+            new_name += ext
 
         new_path = path.parent / new_name
         if new_path.exists() and new_path != path:

--- a/vice/ui/index.html
+++ b/vice/ui/index.html
@@ -367,6 +367,14 @@
           </div>
 
           <div class="settings-row">
+            <div class="s-label"><strong>Container</strong><span>MKV survives crashes better and suits multi-track audio. Discord embeds and browsers need MP4.</span></div>
+            <select id="s-container">
+              <option value="mp4">MP4 (best compatibility)</option>
+              <option value="mkv">MKV (crash-safe)</option>
+            </select>
+          </div>
+
+          <div class="settings-row">
             <div class="s-label"><strong>Video encoder</strong><span>GPU encoders are faster with lower CPU usage</span></div>
             <select id="s-enc">
               <option value="auto">Auto (recommended)</option>
@@ -405,6 +413,17 @@
             <select id="s-gsr-audio">
               <option value="default_output">Default output</option>
             </select>
+          </div>
+
+          <div class="settings-row settings-row-stack">
+            <div class="s-label"><strong>Separate audio tracks</strong><span>Record each source as its own track (gpu-screen-recorder). Players and Discord play only track 1; video editors see every track. Leave empty to mix everything into one track.</span></div>
+            <div class="track-builder">
+              <div class="track-add-row">
+                <select id="s-track-pick"></select>
+                <button class="btn-pill btn-ghost-pill" type="button" onclick="addAudioTrack()">Add track</button>
+              </div>
+              <div id="s-track-list" class="track-list"></div>
+            </div>
           </div>
 
           <div class="settings-row">
@@ -461,6 +480,10 @@
           <div class="settings-row">
             <div class="s-label"><strong>Save clips to</strong><span>Directory where clips are saved</span></div>
             <input type="text" id="s-dir" placeholder="~/Videos/Vice">
+          </div>
+          <div class="settings-row">
+            <div class="s-label"><strong>Tag clips with game</strong><span>Append the detected game to clip filenames, e.g. Vice_Clip_4_Overwatch-2.mp4. Uses the same game list as Discord Rich Presence.</span></div>
+            <label class="toggle"><input type="checkbox" id="s-tag-game"><span class="toggle-track"></span></label>
           </div>
         </div>
 

--- a/vice/ui/scripts/settings.js
+++ b/vice/ui/scripts/settings.js
@@ -1,6 +1,10 @@
 'use strict';
 // settings.js — settings form, persistence, mic/audio/tunnel toggles
 
+// Separate-audio-track ids in order (track 1 first). Mirrors
+// cfg.recording.audio_tracks; empty means "mix into one track".
+let audioTracks = [];
+
 // ═══════════════════════════════════════════════════════════════════
 // Settings — fetch + save against /api/config
 // ═══════════════════════════════════════════════════════════════════
@@ -34,6 +38,7 @@ function syncFormFromCfg() {
 
   pick('s-fps', String(r.fps ?? 60));
   pick('s-res', r.resolution ?? '');
+  pick('s-container', r.container ?? 'mp4');
   pick('s-enc', r.encoder ?? 'auto');
   pick('s-backend', r.backend ?? 'auto');
   document.getElementById('s-audio').checked = r.capture_audio !== false;
@@ -45,6 +50,9 @@ function syncFormFromCfg() {
   document.getElementById('s-key-btn').textContent = clipKey;
   renderClipPresetRows(h.clip_presets || []);
   document.getElementById('s-dir').value  = o.directory  ?? '';
+  document.getElementById('s-tag-game').checked = o.tag_clips_with_game !== false;
+  audioTracks = Array.isArray(r.audio_tracks) ? [...r.audio_tracks] : [];
+  renderAudioTracks();
   document.getElementById('s-port').value = s.port       ?? 8765;
   document.getElementById('s-cf').checked = s.cloudflare_tunnel !== false;
   // Discord
@@ -205,6 +213,11 @@ function renderAudioSources(info, selectedSource = 'default_output') {
   const desired = selectedSource || 'default_output';
   el.innerHTML = '';
   for (const source of sources) el.add(new Option(source.label || source.id, source.id));
+  const pickEl = document.getElementById('s-track-pick');
+  if (pickEl) {
+    pickEl.innerHTML = '';
+    for (const source of sources) pickEl.add(new Option(source.label || source.id, source.id));
+  }
   if (sources.some(source => source.id === desired)) {
     el.value = desired;
     setAudioSourceNote('Choose what gpu-screen-recorder captures');
@@ -298,6 +311,32 @@ function copyTunnelUrl() {
     toast(ok ? 'Public URL copied!' : 'Could not copy', ok ? 'ok' : 'err'));
 }
 
+function addAudioTrack() {
+  const pickEl = document.getElementById('s-track-pick');
+  const id = pickEl ? pickEl.value : '';
+  if (!id) return;
+  if (audioTracks.includes(id)) { toast('That source is already a track', 'err'); return; }
+  audioTracks.push(id);
+  renderAudioTracks();
+}
+
+function removeAudioTrack(index) {
+  audioTracks.splice(index, 1);
+  renderAudioTracks();
+}
+
+function renderAudioTracks() {
+  const list = document.getElementById('s-track-list');
+  if (!list) return;
+  list.innerHTML = '';
+  audioTracks.forEach((id, i) => {
+    const chip = document.createElement('span');
+    chip.className = 'track-chip';
+    chip.innerHTML = `<span class="track-num">${i + 1}</span> ${escHtml(id)} <button type="button" title="Remove track" onclick="removeAudioTrack(${i})">×</button>`;
+    list.appendChild(chip);
+  });
+}
+
 async function saveSettings() {
   const clipPresets = collectClipPresetRows();
   const maxClipDuration = Math.max(
@@ -316,19 +355,24 @@ async function saveSettings() {
       fps:             +document.getElementById('s-fps').value,
       display:         document.getElementById('s-display').value || null,
       resolution:      document.getElementById('s-res').value || null,
+      container:       document.getElementById('s-container').value,
       encoder:         document.getElementById('s-enc').value,
       backend:         document.getElementById('s-backend').value,
       capture_audio:   document.getElementById('s-audio').checked,
       capture_microphone: document.getElementById('clips-mic-toggle').checked,
       wf_microphone_strategy: document.getElementById('s-wf-mic').value,
       gsr_audio_source: document.getElementById('s-gsr-audio').value || 'default_output',
+      audio_tracks:    [...audioTracks],
       gsr_args:        document.getElementById('s-gsr-args').value.trim(),
     },
     hotkeys: {
       clip: document.getElementById('s-key').value,
       clip_presets: clipPresets,
     },
-    output:  { directory: document.getElementById('s-dir').value },
+    output:  {
+      directory: document.getElementById('s-dir').value,
+      tag_clips_with_game: document.getElementById('s-tag-game').checked,
+    },
     sharing: {
       port:              +document.getElementById('s-port').value,
       cloudflare_tunnel: document.getElementById('s-cf').checked,

--- a/vice/ui/styles/settings.css
+++ b/vice/ui/styles/settings.css
@@ -89,3 +89,15 @@ input[type=range]::-webkit-slider-thumb:hover { transform: scale(1.25); }
 .clip-preset-row input[type=number] { width: 82px; }
 .clip-preset-unit { color: var(--text-dim); font-size: 12px; }
 .clip-preset-remove { width: 30px; padding: 0 !important; }
+
+/* Separate-audio-track builder */
+.track-builder { display: flex; flex-direction: column; gap: 10px; align-items: flex-end; }
+.track-add-row { display: flex; gap: 8px; }
+.track-list { display: flex; flex-wrap: wrap; gap: 6px; justify-content: flex-end; max-width: 420px; }
+.track-chip { display: inline-flex; align-items: center; gap: 6px; font-size: 12px;
+  padding: 4px 10px; border: 1px solid var(--line-hi); border-radius: 999px;
+  background: rgba(255,255,255,0.04); }
+.track-chip .track-num { color: var(--accent); font-weight: 600; }
+.track-chip button { background: none; border: none; color: var(--text-dim);
+  cursor: pointer; padding: 0 2px; font-size: 14px; line-height: 1; }
+.track-chip button:hover { color: var(--danger); }


### PR DESCRIPTION
**IMPORTANT: based on `fix/clip-pipeline` — merge that PR first, then this branch shows only its own commit.**


### What it adds

- **`recording.container` (mp4 | mkv), closes #50**: mkv survives crashes better and suits multi-track audio. Clip naming, trim, watermark, rename, share-server scan, and temp cleanup are container-agnostic now; the mp4 moov remux is skipped for mkv. The settings UI has a Container dropdown with a note that Discord embeds/browsers need mp4. Applies to the GSR backend; wf-recorder/ffmpeg stay mp4 with a logged warning. Sessions stay mp4 on purpose (they span games and feed the highlight pipeline).
- **`recording.audio_tracks`, closes #45 and finishes #53**: each listed source becomes its own `-a` flag, which gpu-screen-recorder records as a separate audio track (game / Discord / mic separable in editors). Empty list = the existing single mixed track. The settings UI gets a chip-style track builder fed by the existing audio-sources API (devices, `app:Name`, `app-inverse:Name`). Caveat shown in UI: players and Discord play only track 1.
- **`output.tag_clips_with_game` (default on), closes #72 and the filename half of #11**: clips save as `Vice_Clip_4_Overwatch-2.mp4` when a known game is focused. Reuses the curated games.json + custom-games matching built for Discord Rich Presence — no window-title heuristics, nothing leaves the machine. Detection runs in a thread so a slow compositor call can never delay a clip save. Works where active-window detection works (X11, Hyprland, Sway); elsewhere clips save untagged.

### Verification

- `python -m unittest discover tests/` — 111 tests pass on this branch. New tests: `-c mkv` and invalid-container fallback, one `-a` per track in order, tagged/mixed-container clip numbering, tag sanitization ("Overwatch 2: Beta!" → `Overwatch-2-Beta`), tag callback failure tolerance, mkv clips listed and served by the share server.
- Manual: set container to MKV, save a clip, confirm it plays in the app and in mpv; add tracks `default_output` + `default_input`, clip, open in an editor and see two audio tracks; focus a game from games.json and clip — filename carries the game.

Closes #50, closes #45, closes #72. Comment on #53 explaining the source dropdown + tracks builder now cover its ask, and on #11 noting the filename half is done and event-based auto-clipping is on the roadmap.
