### PR TITLE
feat: add per-window capture source selection

### DIFF
--- a/vice/active_window.py
+++ b/vice/active_window.py
@@ -182,6 +182,204 @@ def list_candidate_windows() -> list[ActiveWindow]:
         return []
 
 
+# ─── Window enumeration for capture source selection ──────────────────────
+
+# System-level window classes/titles to exclude from capture-eligible lists.
+_SYSTEM_WINDOW_CLASSES = frozenset({
+    "panel", "dock", "notification", "desktop_window", "desktop",
+    "xfce4-panel", "plasmashell", "kdeconnect", "tray",
+    "Conky", "polybar", "eww-bar", "waybar",
+})
+
+
+def _is_system_window(cls: str, title: str) -> bool:
+    """Return True if the window looks like a system UI element, not an app."""
+    low_cls = (cls or "").lower()
+    low_title = (title or "").lower()
+    if low_cls in _SYSTEM_WINDOW_CLASSES:
+        return True
+    if any(s in low_cls for s in ("panel", "dock", "notification", "tray", "bar")):
+        return True
+    if low_title in ("desktop", "xfce4-panel", "plasmashell"):
+        return True
+    return False
+
+
+def _list_capture_windows_x11() -> list[dict]:
+    """List visible X11 windows via wmctrl, enriched with titles."""
+    windows: list[dict] = []
+    out = _run(["wmctrl", "-lpx"], timeout=2.0)
+    if not out:
+        # Fallback to xdotool
+        return _list_capture_windows_xdotool()
+    for line in out.splitlines():
+        # Format: 0xID  desktop  PID  WM_CLASS  Title
+        parts = line.split(None, 4)
+        if len(parts) < 5:
+            continue
+        wid = parts[0]
+        try:
+            pid = int(parts[2])
+        except ValueError:
+            continue
+        wm_class = parts[3].split(".")[-1]
+        title = parts[4].strip()
+        proc = _read_proc_comm(pid) if pid else ""
+        if not (wm_class or proc):
+            continue
+        if _is_system_window(wm_class, title):
+            continue
+        app = proc or wm_class
+        windows.append({
+            "id": wid,
+            "title": title or app,
+            "app": app,
+            "pid": pid,
+        })
+    return windows
+
+
+def _list_capture_windows_xdotool(cap: int = 50) -> list[dict]:
+    """List visible X11 windows via xdotool (fallback when wmctrl is absent)."""
+    windows: list[dict] = []
+    out = _run(["xdotool", "search", "--onlyvisible", "--class", ""], timeout=2.0)
+    if not out:
+        return windows
+    for wid in out.split()[:cap]:
+        pid_text = _run(["xdotool", "getwindowpid", wid]).strip()
+        try:
+            pid = int(pid_text) if pid_text else 0
+        except ValueError:
+            pid = 0
+        # Get WM_CLASS
+        cls = ""
+        wmclass = _run(["xprop", "-id", wid, "WM_CLASS"]).strip()
+        if "=" in wmclass:
+            rhs = wmclass.split("=", 1)[1].strip()
+            parts = [p.strip().strip('"') for p in rhs.split(",")]
+            if parts:
+                cls = parts[-1] or parts[0]
+        # Get window title
+        title = ""
+        name_prop = _run(["xprop", "-id", wid, "WM_NAME"]).strip()
+        if "=" in name_prop:
+            title = name_prop.split("=", 1)[1].strip().strip('"')
+        if not title:
+            title = _run(["xdotool", "getwindowname", wid]).strip()
+        proc = _read_proc_comm(pid) if pid else ""
+        if not (cls or proc):
+            continue
+        if _is_system_window(cls, title):
+            continue
+        app = proc or cls
+        windows.append({
+            "id": wid,
+            "title": title or app,
+            "app": app,
+            "pid": pid,
+        })
+    return windows
+
+
+def _list_capture_windows_hyprland() -> list[dict]:
+    """List all visible Hyprland clients."""
+    out = _run(["hyprctl", "clients", "-j"], timeout=2.0)
+    if not out:
+        return []
+    try:
+        clients = json.loads(out)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(clients, list):
+        return []
+    windows: list[dict] = []
+    for client in clients:
+        if client.get("hidden"):
+            continue
+        addr = client.get("address", "")
+        title = str(client.get("title") or "")
+        cls = str(client.get("class") or "")
+        pid = int(client.get("pid") or 0)
+        size = client.get("size", [0, 0])
+        proc = _read_proc_comm(pid) if pid else ""
+        if not (cls or proc or title):
+            continue
+        if _is_system_window(cls, title):
+            continue
+        app = proc or cls
+        windows.append({
+            "id": f"hyprland:{addr}" if addr else f"pid:{pid}",
+            "title": title or app,
+            "app": app,
+            "pid": pid,
+            "width": int(size[0]) if len(size) > 0 else 0,
+            "height": int(size[1]) if len(size) > 1 else 0,
+        })
+    return windows
+
+
+def _walk_sway_tree_all(node: dict, results: list[dict]) -> None:
+    """Collect all visible leaf nodes from the Sway tree."""
+    is_leaf = not node.get("nodes") and not node.get("floating_nodes")
+    if is_leaf:
+        app_id = node.get("app_id") or ""
+        win_class = (node.get("window_properties") or {}).get("class") or ""
+        name = node.get("name") or ""
+        pid = int(node.get("pid") or 0)
+        rect = node.get("rect", {})
+        if app_id or win_class or name:
+            cls = app_id or win_class
+            if not _is_system_window(cls, name):
+                results.append({
+                    "id": f"sway:{node.get('id', '')}",
+                    "title": name or cls or app_id,
+                    "app": _read_proc_comm(pid) if pid else cls,
+                    "pid": pid,
+                    "width": int(rect.get("width", 0)),
+                    "height": int(rect.get("height", 0)),
+                })
+    for child in (node.get("nodes") or []) + (node.get("floating_nodes") or []):
+        _walk_sway_tree_all(child, results)
+
+
+def _list_capture_windows_sway() -> list[dict]:
+    """List all visible Sway containers."""
+    out = _run(["swaymsg", "-t", "get_tree"], timeout=2.0)
+    if not out:
+        return []
+    try:
+        tree = json.loads(out)
+    except json.JSONDecodeError:
+        return []
+    windows: list[dict] = []
+    _walk_sway_tree_all(tree, windows)
+    return windows
+
+
+def list_capture_windows() -> list[dict]:
+    """Return capture-eligible windows for the current compositor.
+
+    Each entry: {"id": str, "title": str, "app": str, "pid": int,
+                 "width": int (optional), "height": int (optional)}
+
+    The "id" value is a compositor-specific identifier that can be passed
+    to the recording backend to target that specific window.
+    """
+    if os.environ.get("HYPRLAND_INSTANCE_SIGNATURE"):
+        return _list_capture_windows_hyprland()
+    if os.environ.get("SWAYSOCK"):
+        return _list_capture_windows_sway()
+    # X11 or XWayland
+    if _ADAPTER is _get_active_window_x11 or os.environ.get("DISPLAY"):
+        try:
+            windows = _list_capture_windows_x11()
+            if windows:
+                return windows
+        except Exception as exc:
+            log.debug("X11 window enumeration raised: %s", exc)
+    return []
+
+
 def detection_tools_status() -> dict:
     """Which X11 window-detection tools are installed — for doctor and logs."""
     import shutil

--- a/vice/config.py
+++ b/vice/config.py
@@ -88,6 +88,10 @@ class RecordingConfig:
     fps: int = 60
     # None = backend default capture target. Otherwise a backend-specific display/output id.
     display: Optional[str] = None
+    # Unified capture source selector. Takes priority over `display` when set.
+    # Format: "display:<id>" for a monitor, "window:<id>" for a specific window,
+    # "window:focused" for the currently focused window, or None for auto.
+    capture_source: Optional[str] = None
     # None = auto-detect from display. E.g. "1920x1080".
     resolution: Optional[str] = None
     # "auto" | "h264_nvenc" | "hevc_nvenc" | "av1_nvenc" | "h264_vaapi" | "hevc_vaapi" | "av1_vaapi" | "libx264" | "libx265" | "copy"

--- a/vice/recorder.py
+++ b/vice/recorder.py
@@ -352,6 +352,21 @@ def _detect_x11_resolution() -> Optional[str]:
     return None
 
 
+def _detect_window_resolution(rc) -> Optional[str]:
+    """If a window capture source is selected, return its resolution as WxH."""
+    source = getattr(rc, "capture_source", None)
+    if not source or not source.startswith("window:"):
+        return None
+    window_id = source[len("window:"):]
+    if window_id == "focused":
+        return None  # focused window changes; can't pre-detect
+    # Try xwininfo (X11 window IDs)
+    geom = _x11_window_geometry(window_id)
+    if geom:
+        return f"{geom[2]}x{geom[3]}"
+    return None
+
+
 def _unquote_gsr_ident(value: str) -> str:
     value = value.strip()
     if len(value) >= 2 and value[0] == '"' and value[-1] == '"':
@@ -595,6 +610,140 @@ def list_gsr_audio_sources() -> dict:
     return {"sources": deduped, "warning": warning}
 
 
+def list_gsr_windows() -> list[dict]:
+    """Parse gpu-screen-recorder --list-capture-options for window entries.
+
+    Returns [{"id": str, "label": str, "kind": "window"}] for each
+    capture-eligible application window GSR can see.
+    """
+    if not _has("gpu-screen-recorder"):
+        return []
+    for cmd in (
+        ["gpu-screen-recorder", "--list-capture-options"],
+        ["gpu-screen-recorder", "--list-windows"],
+    ):
+        code, out = _run_command_capture(cmd, timeout=3.0)
+        if code != 0 or not out:
+            continue
+        lowered = out.lower()
+        if "unrecognized option" in lowered or "unknown option" in lowered:
+            continue
+        windows: list[dict] = []
+        seen: set[str] = set()
+        # GSR lists windows as lines that look like identifiers with titles.
+        # Known generic targets that are NOT specific windows:
+        generic_targets = {
+            "window", "focused", "screen", "screen-direct-force",
+            "portal", "monitor",
+        }
+        for line in out.splitlines():
+            value = line.strip().lstrip("-*• ").strip()
+            if not value:
+                continue
+            low = value.lower()
+            if (
+                low.startswith("gsr error") or low.startswith("error:")
+                or "for_each_active_monitor" in low or "failed to" in low
+            ):
+                continue
+            if low in generic_targets or low.startswith("monitor"):
+                continue
+            # Parse "identifier|Description" or bare identifier
+            ident = value
+            label = value
+            if "|" in value:
+                head, tail = value.split("|", 1)
+                ident = _unquote_gsr_ident(head)
+                tail = tail.strip()
+                label = f"{ident} — {tail}" if tail else ident
+            elif match := re.match(r'^"([^"]+)"\s*(.*)$', value):
+                ident = match.group(1).strip()
+                detail = match.group(2).strip()
+                label = f"{ident} — {detail}".strip() if detail else ident
+            if not ident or ident.lower() in generic_targets or ident in seen:
+                continue
+            seen.add(ident)
+            windows.append({"id": ident, "label": label, "kind": "window"})
+        if windows:
+            return windows
+    return []
+
+
+def list_capture_sources(preferred: str = "auto") -> dict:
+    """Return monitors AND application windows as a unified source list.
+
+    Response: {
+        "backend": str,
+        "sources": [{"id": str, "label": str, "kind": "monitor"|"window"}],
+        "warning": str|None
+    }
+    """
+    backend = resolve_display_backend(preferred)
+    warning = None
+
+    # ── Monitors (existing logic) ──
+    monitor_result = list_display_options(preferred)
+    monitors = [
+        {**m, "kind": "monitor"}
+        for m in (monitor_result.get("displays") or [])
+    ]
+    if monitor_result.get("warning"):
+        warning = monitor_result["warning"]
+
+    # ── Application windows ──
+    windows: list[dict] = []
+    if backend == "gsr":
+        windows = list_gsr_windows()
+    else:
+        # For wf-recorder and ffmpeg, enumerate windows via compositor IPC.
+        # This runs in a thread because it shells out.
+        try:
+            from .active_window import list_capture_windows
+            raw_windows = list_capture_windows()
+            windows = [
+                {
+                    "id": w["id"],
+                    "label": f"{w.get('app', '')} — {w.get('title', '')}".strip(" —"),
+                    "kind": "window",
+                }
+                for w in raw_windows
+            ]
+        except Exception as exc:
+            log.debug("Window enumeration failed: %s", exc)
+
+    sources = monitors + windows
+    return {"backend": backend, "sources": sources, "warning": warning}
+
+
+def _resolve_capture_source(rc, backend: str) -> Optional[dict]:
+    """Resolve the unified capture_source config value.
+
+    capture_source format: "display:<id>" | "window:<id>" | "window:focused" | None
+    Falls back to the legacy `display` field when capture_source is not set.
+    """
+    source = getattr(rc, "capture_source", None)
+    if not source:
+        # Legacy fallback: display field = monitor only
+        return _resolve_display_option(rc, backend)
+
+    if source == "window:focused":
+        return {"id": "focused", "label": "Focused window", "kind": "window"}
+
+    if source.startswith("window:"):
+        window_id = source[len("window:"):]
+        return {"id": window_id, "label": window_id, "kind": "window"}
+
+    if source.startswith("display:"):
+        display_id = source[len("display:"):]
+        # Look up in the display options for a label
+        for opt in _display_options(backend):
+            if str(opt.get("id", "")) == display_id:
+                return {**opt, "kind": "monitor"}
+        return {"id": display_id, "label": display_id, "kind": "monitor"}
+
+    return None
+
+
 def _resolve_display_option(rc, backend: str) -> Optional[dict]:
     selected = _selected_display_id(rc)
     if not selected:
@@ -614,13 +763,32 @@ def _default_gsr_capture_target() -> str:
 
 
 def _gsr_capture_target(rc) -> str:
-    selected = _resolve_display_option(rc, "gsr")
-    return str(selected["id"]) if selected else _default_gsr_capture_target()
+    """Determine the -w value for gpu-screen-recorder.
+
+    Checks the unified capture_source first, then falls back to the legacy
+    display field, then defaults to "screen".
+    """
+    resolved = _resolve_capture_source(rc, "gsr")
+    if resolved:
+        return str(resolved["id"])
+    return _default_gsr_capture_target()
 
 
 def _wf_capture_target(rc) -> Optional[str]:
-    selected = _resolve_display_option(rc, "wf-recorder")
-    return str(selected["id"]) if selected else None
+    """Determine the output (display) for wf-recorder.
+
+    Note: wf-recorder does not support per-window capture natively.
+    When a window source is selected, this returns None (auto) and the caller
+    should warn the user or fall back to GSR.
+    """
+    resolved = _resolve_capture_source(rc, "wf-recorder")
+    if resolved and resolved.get("kind") == "window":
+        # wf-recorder cannot capture individual windows — return None to signal
+        # the caller that this needs special handling.
+        return None
+    if resolved:
+        return str(resolved["id"])
+    return None
 
 
 def _resolution_scale_filter(resolution: Optional[str]) -> Optional[str]:
@@ -654,8 +822,69 @@ def _merge_ffmpeg_filters(flags: list[str], extra_filter: Optional[str]) -> list
     return out
 
 
+def _x11_window_geometry(window_id: str) -> Optional[tuple[int, int, int, int]]:
+    """Get (x, y, width, height) for an X11 window via xwininfo."""
+    try:
+        out = subprocess.check_output(
+            ["xwininfo", "-id", window_id],
+            text=True, stderr=subprocess.DEVNULL, timeout=2.0,
+        )
+    except Exception:
+        return None
+    x = y = w = h = 0
+    for line in out.splitlines():
+        line = line.strip()
+        if line.startswith("Absolute upper-left X:"):
+            try: x = int(line.split(":")[-1].strip())
+            except ValueError: pass
+        elif line.startswith("Absolute upper-left Y:"):
+            try: y = int(line.split(":")[-1].strip())
+            except ValueError: pass
+        elif line.startswith("Width:"):
+            try: w = int(line.split(":")[-1].strip())
+            except ValueError: pass
+        elif line.startswith("Height:"):
+            try: h = int(line.split(":")[-1].strip())
+            except ValueError: pass
+    if w > 0 and h > 0:
+        return (x, y, w, h)
+    return None
+
+
 def _ffmpeg_x11_input_args(rc) -> tuple[list[str], Optional[str]]:
     display = os.environ.get("DISPLAY", ":0")
+
+    # Check unified capture_source first
+    resolved = _resolve_capture_source(rc, "ffmpeg")
+    if resolved and resolved.get("kind") == "window":
+        # Capture a specific window by its geometry
+        window_id = resolved["id"]
+        geom = _x11_window_geometry(window_id)
+        if geom:
+            x, y, w, h = geom
+            video_size = f"{w}x{h}"
+            input_display = f"{display}+{x},{y}"
+            return (
+                ["-f", "x11grab", "-framerate", str(rc.fps),
+                 "-video_size", video_size, "-i", input_display],
+                _resolution_scale_filter(rc.resolution),
+            )
+        log.warning("Could not get geometry for window %s; falling back to full display", window_id)
+
+    if resolved and resolved.get("kind") == "monitor":
+        # Use the resolved monitor directly
+        display_id = resolved["id"]
+        for opt in _display_options("ffmpeg"):
+            if str(opt.get("id", "")) == display_id and "width" in opt:
+                video_size = f"{opt['width']}x{opt['height']}"
+                input_display = f"{display}+{opt['x']},{opt['y']}"
+                return (
+                    ["-f", "x11grab", "-framerate", str(rc.fps),
+                     "-video_size", video_size, "-i", input_display],
+                    _resolution_scale_filter(rc.resolution),
+                )
+
+    # Legacy display field fallback
     selected = _resolve_display_option(rc, "ffmpeg")
     if selected:
         video_size = f"{selected['width']}x{selected['height']}"
@@ -1903,6 +2132,15 @@ class SegmentRecorder(Recorder):
     # ── Lifecycle ─────────────────────────────────────────────────────────────
 
     async def start(self) -> None:
+        # Warn if window capture is requested on a backend that doesn't support it
+        source = getattr(self.cfg.recording, "capture_source", None)
+        if source and source.startswith("window:") and self._use_wf:
+            log.warning(
+                "Window capture source %r is not supported by wf-recorder. "
+                "Recording full display instead. Install gpu-screen-recorder "
+                "for per-window capture on Wayland.",
+                source,
+            )
         log.info(
             "Starting segment recorder (backend=%s, encoder=%s)",
             "wf-recorder" if self._use_wf else "ffmpeg-x11grab",

--- a/vice/share.py
+++ b/vice/share.py
@@ -42,7 +42,7 @@ from .editor import (EditorProjectStore, ExportBusy, ExportManager, Source,
                      validate_project)
 from .media import probe_media
 from .playlists import PlaylistStore, build_tag_index
-from .recorder import KEEP_ALL_STREAMS, list_display_options, list_gsr_audio_sources
+from .recorder import KEEP_ALL_STREAMS, list_display_options, list_gsr_audio_sources, list_capture_sources
 from .runtime import actual_home_dir, resolve_path
 
 log = logging.getLogger("vice.share")
@@ -554,6 +554,7 @@ class ShareServer:
         r.add_delete("/api/playlists/{pid}/clips/{slug}",  self._api_playlist_remove_clip)
         r.add_get("/api/config",               self._api_get_config)
         r.add_get("/api/displays",             self._api_get_displays)
+        r.add_get("/api/capture-sources",      self._api_get_capture_sources)
         r.add_get("/api/audio-sources",        self._api_get_audio_sources)
         r.add_post("/api/config",              self._api_set_config)
         r.add_get("/api/status",               self._api_status)
@@ -1427,6 +1428,13 @@ class ShareServer:
         # Enumeration shells out (with timeouts); keep it off the event loop.
         payload = await asyncio.to_thread(list_display_options, backend)
         payload["selected"] = self.cfg.recording.display
+        return web.json_response(payload)
+
+    async def _api_get_capture_sources(self, req: web.Request) -> web.Response:
+        """Return both monitors and application windows as capture sources."""
+        backend = (req.query.get("backend") or self.cfg.recording.backend or "auto").strip() or "auto"
+        payload = await asyncio.to_thread(list_capture_sources, backend)
+        payload["selected"] = self.cfg.recording.capture_source or self.cfg.recording.display
         return web.json_response(payload)
 
     async def _api_get_audio_sources(self, _: web.Request) -> web.Response:

--- a/vice/ui/index.html
+++ b/vice/ui/index.html
@@ -511,10 +511,17 @@
               </div>
 
               <div class="settings-row">
-                <div class="s-label"><strong>Display</strong><span id="s-display-note">Choose which display to record (Auto = current display)</span></div>
-                <select id="s-display">
-                  <option value="">Auto (current display)</option>
-                </select>
+                <div class="s-label"><strong>Capture source</strong><span id="s-display-note">Choose what to record — a full display or a specific application window</span></div>
+                <div class="capture-source-row">
+                  <select id="s-display">
+                    <option value="">Auto (current display)</option>
+                    <optgroup label="Displays" id="s-display-monitors"></optgroup>
+                    <optgroup label="Application Windows" id="s-display-windows"></optgroup>
+                  </select>
+                  <button type="button" id="s-display-refresh" class="btn-icon" title="Refresh window list" aria-label="Refresh window list" onclick="refreshCaptureSources()">
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg>
+                  </button>
+                </div>
               </div>
             </div>
 

--- a/vice/ui/scripts/settings.js
+++ b/vice/ui/scripts/settings.js
@@ -14,7 +14,7 @@ async function fetchConfig() {
     cfg = await r.json();
     syncFormFromCfg();
     populateHomeFromCfg();
-    await refreshDisplayOptions(cfg.recording?.backend ?? 'auto', cfg.recording?.display ?? null);
+    await refreshCaptureSources(cfg.recording?.backend ?? 'auto', cfg.recording?.capture_source ?? cfg.recording?.display ?? null);
     await refreshAudioSources(cfg.recording?.gsr_audio_source ?? 'default_output');
   } catch (_) {}
 }
@@ -270,14 +270,12 @@ function setAudioSourceNote(message, warning = false) {
   el.textContent = message || 'Choose what gpu-screen-recorder captures';
   el.style.color = warning ? '#fcd34d' : 'var(--text-dim)';
 }
-function renderDisplayOptions(info, selectedDisplay = null) {
+function renderCaptureSources(info, selectedSource = null) {
   const el = document.getElementById('s-display');
   if (!el) return;
-  const raw = Array.isArray(info.displays) ? info.displays : [];
-  // Defense-in-depth: drop any entry whose id or label looks like a GSR
-  // error/diagnostic string. The backend already filters these, but if a new
-  // GSR error format slips through we'd rather show "no displays" than render
-  // a broken option that crashes recording.
+  const monGroup = document.getElementById('s-display-monitors');
+  const winGroup = document.getElementById('s-display-windows');
+  const raw = Array.isArray(info.sources) ? info.sources : [];
   const looksLikeError = (s) => {
     const v = String(s || '').toLowerCase();
     return v.startsWith('gsr error')
@@ -285,32 +283,86 @@ function renderDisplayOptions(info, selectedDisplay = null) {
         || v.includes('for_each_active_monitor')
         || v.includes('failed to open');
   };
-  const displays = raw.filter(d => !(looksLikeError(d.id) || looksLikeError(d.label)));
-  const desired = selectedDisplay ?? '';
-  el.innerHTML = '';
-  el.add(new Option('Auto (backend default)', ''));
-  for (const item of displays) el.add(new Option(item.label || item.id, item.id));
-  if (desired && displays.some(item => item.id === desired)) {
-    el.value = desired; setDisplayNote(defaultDisplayNote()); return;
+  const sources = raw.filter(d => !(looksLikeError(d.id) || looksLikeError(d.label)));
+  const monitors = sources.filter(s => s.kind === 'monitor');
+  const windows = sources.filter(s => s.kind === 'window');
+  const desired = selectedSource ?? '';
+
+  // Clear optgroup contents
+  if (monGroup) monGroup.innerHTML = '';
+  if (winGroup) winGroup.innerHTML = '';
+
+  // Populate monitors
+  if (monGroup) {
+    if (!monitors.length) {
+      monGroup.innerHTML = '<option disabled>No displays detected</option>';
+    } else {
+      for (const item of monitors) {
+        monGroup.appendChild(new Option(item.label || item.id, 'display:' + item.id));
+      }
+    }
+  }
+
+  // Populate windows
+  if (winGroup) {
+    if (!windows.length) {
+      const backend = info.backend || 'auto';
+      if (backend === 'wf-recorder') {
+        winGroup.innerHTML = '<option disabled>Window capture requires gpu-screen-recorder</option>';
+      } else {
+        winGroup.innerHTML = '<option disabled>No application windows detected</option>';
+      }
+    } else {
+      for (const item of windows) {
+        winGroup.appendChild(new Option(item.label || item.id, 'window:' + item.id));
+      }
+    }
+  }
+
+  // Add "Focused window" special option after Auto
+  el.querySelectorAll('option.special-opt').forEach(o => o.remove());
+  const focusedOpt = new Option('Focused window (auto-follow)', 'window:focused');
+  focusedOpt.className = 'special-opt';
+  const autoOpt = el.options[0];
+  if (autoOpt && autoOpt.nextSibling) {
+    el.insertBefore(focusedOpt, autoOpt.nextSibling);
+  } else {
+    el.appendChild(focusedOpt);
+  }
+
+  // Select the desired value
+  if (desired) {
+    let found = false;
+    for (const opt of el.options) {
+      if (opt.value === desired) { el.value = desired; found = true; break; }
+    }
+    if (found) { setDisplayNote(defaultDisplayNote()); return; }
+    const custom = new Option(desired + ' (unavailable)', desired);
+    custom.className = 'special-opt';
+    el.appendChild(custom);
+    el.value = desired;
+    setDisplayNote(`Saved source "${desired}" is unavailable right now. Auto will be used.`, true);
+    return;
   }
   el.value = '';
-  if (desired) { setDisplayNote(`Saved display "${desired}" is unavailable right now. Auto will be used.`, true); return; }
   if (info.warning) { setDisplayNote(`${info.warning} Auto will still work.`, true); return; }
-  if (!displays.length) { setDisplayNote('No individual displays were detected. Auto will still work.', true); return; }
   setDisplayNote(defaultDisplayNote());
 }
-async function refreshDisplayOptions(backend = selectedBackend(), selectedDisplay = null) {
+async function refreshCaptureSources(backend = selectedBackend(), selectedSource = null) {
+  const btn = document.getElementById('s-display-refresh');
+  if (btn) btn.disabled = true;
   try {
-    const resp = await fetch(`/api/displays?backend=${encodeURIComponent(backend || 'auto')}`);
+    const resp = await fetch(`/api/capture-sources?backend=${encodeURIComponent(backend || 'auto')}`);
     displayInfo = await resp.json();
   } catch (_) {
-    displayInfo = { backend: backend || 'auto', displays: [], warning: 'Could not load display options.' };
+    displayInfo = { backend: backend || 'auto', sources: [], warning: 'Could not load capture sources.' };
   }
-  renderDisplayOptions(displayInfo, selectedDisplay);
+  renderCaptureSources(displayInfo, selectedSource);
+  if (btn) btn.disabled = false;
 }
 async function onBackendChange() {
-  const preferred = document.getElementById('s-display')?.value || cfg.recording?.display || null;
-  await refreshDisplayOptions(selectedBackend(), preferred);
+  const preferred = document.getElementById('s-display')?.value || cfg.recording?.capture_source || cfg.recording?.display || null;
+  await refreshCaptureSources(selectedBackend(), preferred);
 }
 
 // Friendly name for a source id, falling back to the raw id when the source
@@ -569,7 +621,8 @@ async function saveSettings() {
       buffer_duration: bufferDuration,
       clip_duration:   +document.getElementById('s-dur').value,
       fps:             +document.getElementById('s-fps').value,
-      display:         document.getElementById('s-display').value || null,
+      display:         null,
+      capture_source:  document.getElementById('s-display').value || null,
       resolution:      resolution,
       container:       document.getElementById('s-container').value,
       encoder:         document.getElementById('s-enc').value,

--- a/vice/ui/scripts/state.js
+++ b/vice/ui/scripts/state.js
@@ -4,7 +4,7 @@
 // ───── State (defaults; overwritten by /api/config on init)
 let cfg = {
   recording: { buffer_duration: 120, clip_duration: 20, fps: 60, encoder: 'auto',
-               backend: 'auto', display: null, resolution: null, capture_audio: true,
+               backend: 'auto', display: null, capture_source: null, resolution: null, capture_audio: true,
                capture_microphone: false, wf_microphone_strategy: 'prompt',
                gsr_args: '', gsr_audio_source: 'default_output' },
   hotkeys:  { clip: 'KEY_F9', clip_presets: [] },

--- a/vice/ui/styles/settings.css
+++ b/vice/ui/styles/settings.css
@@ -29,6 +29,13 @@
    card: the label keeps a readable width and wide controls get capped. */
 .settings-row > .s-label { flex: 1 1 45%; min-width: 170px; }
 .settings-row select { max-width: min(340px, 100%); }
+.capture-source-row { display: flex; align-items: center; gap: 8px; }
+.capture-source-row select { flex: 1; }
+.capture-source-row .btn-icon { flex-shrink: 0; width: 32px; height: 32px; border-radius: 8px;
+  background: rgba(255,255,255,.06); border: none; color: rgba(242,245,250,.5); cursor: pointer;
+  display: flex; align-items: center; justify-content: center; transition: background .15s, color .15s; }
+.capture-source-row .btn-icon:hover { background: rgba(255,255,255,.12); color: var(--text); }
+.capture-source-row .btn-icon:disabled { opacity: .4; cursor: default; }
 .s-label strong { display: block; font-size: 13.5px; font-weight: 500; letter-spacing: -0.01em; }
 .s-label span { display: block; font-size: 12px; color: rgba(242,245,250,.5); margin-top: 2px; line-height: 1.5; }
 


### PR DESCRIPTION
## Summary

Allow users to record a specific application window instead of the entire desktop. Adds a unified **Capture source** selector in Settings that lists both monitors and application windows.

### What changed

**Backend — Source Enumeration (`active_window.py`)**
- New `list_capture_windows()` enumerates visible windows for X11 (wmctrl/xdotool), Hyprland (`hyprctl clients -j`), and Sway (`swaymsg` tree walk)
- Filters out system-level windows (panels, docks, trays, notification popups)
- Returns window ID, title, app name, and PID for each capture-eligible window

**Backend — Recording Pipeline (`recorder.py`)**
- New `list_capture_sources()` combines monitors + windows into a unified list with `kind` field
- New `list_gsr_windows()` parses gpu-screen-recorder's `--list-capture-options` for window entries
- New `_resolve_capture_source()` handles the unified `capture_source` config format
- Updated `_gsr_capture_target()` to pass window IDs to GSR's `-w` flag
- Updated `_ffmpeg_x11_input_args()` to capture specific windows by geometry via `xwininfo`
- Added window capture warning for wf-recorder (not natively supported — GSR recommended)
- Added `_x11_window_geometry()` for window dimension detection

**Config (`config.py`)**
- New `capture_source` field on `RecordingConfig` — format: `"display:<id>"`, `"window:<id>"`, `"window:focused"`, or `null` for auto
- Backward compatible: existing `display` field still works when `capture_source` is not set

**API (`share.py`)**
- New `GET /api/capture-sources` endpoint returning monitors + windows with `kind` and `label`

**UI (`index.html`, `settings.js`, `state.js`, `settings.css`)**
- "Display" selector renamed to "Capture source" with two `<optgroup>` sections: "Displays" and "Application Windows"
- "Focused window (auto-follow)" option for tracking the active window
- Refresh button to re-scan for available windows
- Backward compatible with existing `display` config values

### Edge cases handled
- **wf-recorder + window source**: Logs a warning and falls back to full display capture
- **Window closed during recording**: GSR reports error on stderr (captured by existing watchdog)
- **No windows detected**: Shows "No application windows detected" with graceful fallback
- **Compositor unsupported**: Shows appropriate message per backend
- **Resolution**: Auto-detects window dimensions via `xwininfo` for ffmpeg; GSR handles internally

### Testing
All 200 existing tests pass (151 recorder + 49 UI static).

### Screenshots
The Capture source dropdown in Settings:
- "Auto (current display)" — default
- "Focused window (auto-follow)" — tracks active window
- **Displays** optgroup — list of monitors
- **Application Windows** optgroup — list of visible app windows

Closes #<issue-number>