### PR TITLE
Adding 2 games to games.json

### DIFF
--- a/vice/data/games.json
+++ b/vice/data/games.json
@@ -292,6 +292,7 @@
   {"name": "Star Wars Battlefront II", "matches": ["starwarsbattlefrontii.exe", "starwarsbattlefrontii", "steam_app_1237950"]},
   {"name": "Star Wars: The Old Republic", "matches": ["swtor.exe", "starwarstheoldrepublic", "steam_app_1286830"]},
   {"name": "StarCraft II", "matches": ["SC2_x64.exe", "SC2.exe", "starcraft ii"]},
+  {"name": "Star Citizen", "matches": ["StarCitizen.exe"]},
   {"name": "Stellar Blade", "matches": ["SB-Win64-Shipping.exe", "stellarblade", "steam_app_3489700"]},
   {"name": "Stray", "matches": ["Stray-Win64-Shipping.exe", "steam_app_1332010"]},
   {"name": "Street Fighter V", "matches": ["StreetFighterV.exe", "streetfighterv", "steam_app_310950"]},

--- a/vice/data/games.json
+++ b/vice/data/games.json
@@ -309,6 +309,7 @@
   {"name": "Timberborn", "matches": ["Timberborn.exe", "timberborn", "steam_app_1062090"]},
   {"name": "Titanfall 2", "matches": ["Titanfall2.exe", "titanfall2", "steam_app_1237970"]},
   {"name": "Trackmania", "matches": ["Trackmania.exe", "trackmania", "steam_app_2225070"]},
+  {"name": "Trailmakers", "matches": ["Trailmakers.exe", "steam_app_585420"]},
   {"name": "Two Point Museum", "matches": ["TwoPointMuseum.exe", "twopointmuseum", "steam_app_2185060"]},
   {"name": "Ultrakill", "matches": ["ULTRAKILL.exe", "ultrakill", "steam_app_1229490"]},
   {"name": "Under Night In-Birth II", "matches": ["UNI2.exe", "undernightinbirthii", "steam_app_2076010"]},


### PR DESCRIPTION
I added **Star Citizen** and **Trailmakers** to the games.json. I have tested them and they worked fine for me and got recognized. 
`{"name": "Star Citizen", "matches": ["StarCitizen.exe"]},`
`{"name": "Trailmakers", "matches": ["Trailmakers.exe", "steam_app_585420"]},`


I also tried adding **Planet Zoo** and **Space Engine**, they didn't get recognized for me tho.

`{"name": "Planet Zoo", "matches": ["PlanetZoo.exe", "steam_app_703080"]},`
`{"name": "Space Engine", "matches": ["SpaceEngine.exe", "steam_app_314650"]},`

_sorry if the messy PR I've never made one before._