### PR TITLE
Stop the UI holding video and thumbnails it cannot show

### DIFF
--- a/vice/ui/scripts/clips.js
+++ b/vice/ui/scripts/clips.js
@@ -21,15 +21,46 @@ async function fetchClips() {
 }
 
 let activePreviewVideo = null;
+
+// A <video> holds its decoded buffer for as long as a source is attached, and
+// an element that carries src from the moment the card is built gets a media
+// player whether or not it is ever hovered. Cards are therefore built with the
+// URL parked in data-src; it becomes src on hover and is dropped again once
+// the pointer has been gone a moment. Waiting instead of releasing on the spot
+// means sweeping the pointer across the grid, or coming straight back to the
+// card you just left, does not pay to attach twice.
+const PREVIEW_RELEASE_MS = 4000;
+
+function previewAttach(vid) {
+  clearTimeout(vid._releaseTimer);
+  vid._releaseTimer = null;
+  if (!vid.getAttribute('src') && vid.dataset.src) vid.src = vid.dataset.src;
+}
+
+function previewRelease(vid) {
+  clearTimeout(vid._releaseTimer);
+  vid._releaseTimer = setTimeout(() => {
+    vid._releaseTimer = null;
+    if (activePreviewVideo === vid || !vid.getAttribute('src')) return;
+    vid.removeAttribute('src');
+    // Dropping the attribute alone leaves the buffer where it is; load() is
+    // what tears the player down. The failure handlers below only act on an
+    // element that still has a src, so this never reads as a decode error.
+    try { vid.load(); } catch (_) {}
+  }, PREVIEW_RELEASE_MS);
+}
+
 function stopActivePreview(resetTime = true) {
   if (!activePreviewVideo) return;
+  const vid = activePreviewVideo;
   try {
-    activePreviewVideo.pause();
-    if (resetTime) activePreviewVideo.currentTime = 0;
+    vid.pause();
+    if (resetTime) vid.currentTime = 0;
   } catch (_) {}
-  const card = activePreviewVideo.closest('.clip-card');
+  const card = vid.closest('.clip-card');
   if (card) card.classList.remove('preview-on');
   activePreviewVideo = null;
+  previewRelease(vid);
 }
 // Hover previews resolve from the hovered element, not the slug: card ids
 // are duplicated across the grid and both home rows, so an id lookup could
@@ -41,6 +72,7 @@ function startPreview(el) {
   if (activePreviewVideo && activePreviewVideo !== vid) stopActivePreview(true);
   card.classList.add('preview-on');
   activePreviewVideo = vid;
+  previewAttach(vid);
   const maybe = vid.play();
   if (maybe && typeof maybe.catch === 'function') maybe.catch(() => {});
 }
@@ -51,6 +83,7 @@ function stopPreview(el) {
   card.classList.remove('preview-on');
   try { vid.pause(); vid.currentTime = 0; } catch (_) {}
   if (activePreviewVideo === vid) activePreviewVideo = null;
+  previewRelease(vid);
 }
 
 function currentPlaylist() {
@@ -154,7 +187,7 @@ function cardHTML(c) {
   const hoverHandlers = 'onpointerenter="startPreview(this)" onpointerleave="stopPreview(this)"';
   const mediaHtml = c.thumb_url
     ? `<img src="${escAttr(c.thumb_url)}" loading="lazy" alt="" draggable="false">
-       <video class="preview-video" src="${escAttr(c.video_url)}" muted loop playsinline preload="none"></video>`
+       <video class="preview-video" data-src="${escAttr(c.video_url)}" muted loop playsinline preload="none"></video>`
     : `<div class="thumb-placeholder">${svgEl('film', 32)}</div>`;
 
   const shareDisabled = !c.share_url;

--- a/vice/ui/scripts/editor-core.js
+++ b/vice/ui/scripts/editor-core.js
@@ -438,6 +438,7 @@ function editorLeave() {
   document.querySelector('.stage').classList.remove('stage-editor');
   document.getElementById('quit-row')?.classList.remove('ed-hidden');
   edSetPlaying(false);
+  edReleasePool();
   if (edDirty) edSaveNow();
 }
 

--- a/vice/ui/scripts/editor-preview.js
+++ b/vice/ui/scripts/editor-preview.js
@@ -79,6 +79,37 @@ function edInitStage() {
 // ═══════════════════════════════════════════════════════════════════
 // Video pool
 // ═══════════════════════════════════════════════════════════════════
+
+// Detaching an element does not free what it decoded — the source has to go
+// first, and load() is what actually tears the player down.
+function edDropVideo(v) {
+  v.pause();
+  v.removeAttribute('src');
+  v._key = null;
+  try { v.load(); } catch (_) {}
+  v.remove();
+}
+
+// Three elements per video track, each holding a clip it has decoded, is a
+// reasonable thing to keep while the editor is on screen and a poor thing to
+// keep for the rest of the session once it is not. Called on the way out; the
+// pool rebuilds itself on the next edRenderPreviewFrame.
+function edReleasePool() {
+  Object.keys(edPool).forEach(tid => {
+    edPool[tid].els.forEach(edDropVideo);
+    delete edPool[tid];
+  });
+  edPoolKey = '';
+  edMaster = null;
+  Object.keys(edAudioPool).forEach(id => {
+    const a = edAudioPool[id];
+    a.pause();
+    a.removeAttribute('src');
+    try { a.load(); } catch (_) {}
+    delete edAudioPool[id];
+  });
+}
+
 function edSyncPool() {
   const stage = document.getElementById('ed-stage');
   const vts = edVideoTracks();
@@ -88,7 +119,7 @@ function edSyncPool() {
 
   Object.keys(edPool).forEach(tid => {
     if (!vts.find(t => t.id === tid)) {
-      edPool[tid].els.forEach(v => { v.pause(); v.remove(); });
+      edPool[tid].els.forEach(edDropVideo);
       delete edPool[tid];
     }
   });

--- a/vice/ui/scripts/editor-timeline.js
+++ b/vice/ui/scripts/editor-timeline.js
@@ -80,7 +80,9 @@ function edItemHTML(it) {
       <div class="ed-handle r" data-handle="r"><div class="ed-handle-bar"></div></div>
     </div>`;
   }
-  const thumb = c && c.thumb_url ? `<img src="${escAttr(c.thumb_url)}" alt="" draggable="false">` : '';
+  // Lazy like the library list: a long timeline scrolls well past its own
+  // width, and a thumb costs about 900 KB once decoded.
+  const thumb = c && c.thumb_url ? `<img src="${escAttr(c.thumb_url)}" loading="lazy" alt="" draggable="false">` : '';
   return `<div class="ed-item ed-item-clip${sel}${miss}" ${base}>
     ${thumb}<div class="ed-item-shade"></div>
     <div class="ed-item-hd">

--- a/vice/ui/styles/clips.css
+++ b/vice/ui/styles/clips.css
@@ -29,10 +29,17 @@
 /* ── Clip cards ─────────────────────────────────────────────────── */
 .clips-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 14px; }
 
+/* content-visibility lets the engine skip layout, paint and — the part that
+   matters — the decoded thumbnail bitmap for cards scrolled out of view. A
+   640px thumb costs about 900 KB decoded, so a large reel was holding a few
+   hundred MB of bitmaps it could not see, plus a backdrop blur per card. The
+   auto keyword means the remembered size is used once a card has rendered
+   once; the length is only the first guess, so the scrollbar does not jump. */
 .clip-card { position: relative; background: var(--card-sheen), rgba(255,255,255,.02);
   backdrop-filter: blur(26px); border-radius: var(--r-card);
   box-shadow: var(--glass-edge), 0 10px 30px rgba(0,0,0,.35);
   transition: transform .25s var(--ease), box-shadow .25s;
+  content-visibility: auto; contain-intrinsic-size: auto 205px;
   animation: cardIn .4s var(--ease) backwards; }
 .clip-card:hover { transform: translateY(-3px); }
 @keyframes cardIn { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: translateY(0); } }


### PR DESCRIPTION
The grid builds a card for every clip with no windowing, and `loading="lazy"` only defers the fetch, so a card's decoded thumb stays once it's been scrolled past. `content-visibility: auto` lets the engine drop it again; `contain-intrinsic-size` carries a guess at card height so the scrollbar is right before anything renders. Made the timeline thumb lazy too, it was the last eager `<img>`.

Cards were also built with `src` on the preview `<video>`, and `stopPreview` only paused, so a player stayed attached for every card hovered. The URL moves to `data-src`, becomes `src` on hover, and drops a few seconds after the pointer leaves. The delay keeps a sweep across the grid from attaching twice. `removeAttribute` alone leaves the buffer, so it calls `load()` after, like `closePlayerBar` does.

Same in the editor: `editorLeave` left all three `<video>` per track attached, so opening it once held them for the session. It drops the pool on the way out now. Nothing changes while the editor is open.
