### PR TITLE
Add GeoGuessr Steam Edition to game matches list

### DIFF
--- a/vice/data/games.json
+++ b/vice/data/games.json
@@ -181,6 +181,7 @@
   {"name": "Frostpunk", "matches": ["Frostpunk.exe", "steam_app_323190"]},
   {"name": "Frostpunk 2", "matches": ["Frostpunk2-Win64-Shipping.exe", "steam_app_1601580"]},
   {"name": "Garry's Mod", "matches": ["gmod.exe", "garrysmod", "steam_app_4000"]},
+  {"name": "GeoGuessr Steam Edition", "matches": ["GeoGuessr.exe", "geoguessr", "geoguessrsteamedition", "steam_app_3478870"]}
   {"name": "Getting Over It", "matches": ["Getting Over It.exe", "gettingoverit", "steam_app_240720"]},
   {"name": "Golf With Your Friends", "matches": ["Golf With Your Friends.exe", "golfwithyourfriends", "steam_app_431240"]},
   {"name": "Granblue Fantasy Versus: Rising", "matches": ["GBVSR.exe", "granbluefantasyversusrising", "steam_app_2157560"]},

--- a/vice/data/games.json
+++ b/vice/data/games.json
@@ -181,7 +181,7 @@
   {"name": "Frostpunk", "matches": ["Frostpunk.exe", "steam_app_323190"]},
   {"name": "Frostpunk 2", "matches": ["Frostpunk2-Win64-Shipping.exe", "steam_app_1601580"]},
   {"name": "Garry's Mod", "matches": ["gmod.exe", "garrysmod", "steam_app_4000"]},
-  {"name": "GeoGuessr Steam Edition", "matches": ["GeoGuessr.exe", "geoguessr", "geoguessrsteamedition", "steam_app_3478870"]}
+  {"name": "GeoGuessr Steam Edition", "matches": ["GeoGuessr.exe", "geoguessr", "geoguessrsteamedition", "steam_app_3478870"]},
   {"name": "Getting Over It", "matches": ["Getting Over It.exe", "gettingoverit", "steam_app_240720"]},
   {"name": "Golf With Your Friends", "matches": ["Golf With Your Friends.exe", "golfwithyourfriends", "steam_app_431240"]},
   {"name": "Granblue Fantasy Versus: Rising", "matches": ["GBVSR.exe", "granbluefantasyversusrising", "steam_app_2157560"]},


### PR DESCRIPTION
## Description
Ajoute "GeoGuessr Steam Edition" à la liste des correspondances de jeux, qui manquait précédemment.

## Changements
- Ajout de l'entrée `GeoGuessr Steam Edition` (Steam App ID: 3478870)
- Positionnée par ordre alphabétique entre "Garry's Mod" et "Getting Over It"

## Notes
- L'ID Steam (steam_app_3478870) est confirmé via la Steam Store page.
- Le nom exact de l'exécutable n'a pas pu être vérifié directement (source bloquant les requêtes automatisées) ; à confirmer/corriger si besoin sur une installation réelle.