### PR TITLE
Fix Arch installer Python selection and PyQt6 dependency detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -753,7 +753,6 @@ clean_previous_local_install() {
     stop_running_service_for_reinstall
 
     rm -f "$USER_BIN/vice" "$USER_BIN/vice-app"
-    rm -rf "$VENV_DIR"
 
     shopt -s nullglob
     local stale_paths=(
@@ -776,7 +775,6 @@ clean_previous_local_install() {
 
 install_vice_venv() {
     info "Creating a dedicated virtual environment at $VENV_DIR"
-    rm -rf "$VENV_DIR"
 
     # On Arch-family systems, pacman installs Python modules for the distro
     # interpreter under /usr/bin. A pyenv/asdf/conda Python earlier in PATH
@@ -801,6 +799,8 @@ install_vice_venv() {
         info "System PyQt6 + QtWebEngine are importable; preserving distro H.264 support."
     fi
 
+    clean_previous_local_install
+    rm -rf "$VENV_DIR"
     "$python_bin" -m venv --system-site-packages "$VENV_DIR"
     "$VENV_DIR/bin/python" -m pip install --upgrade pip
 
@@ -897,7 +897,6 @@ PY
 }
 
 info "Installing Vice Python package..."
-clean_previous_local_install
 install_vice_venv
 
 # Ensure $USER_BIN is on PATH for the rest of this script.

--- a/install.sh
+++ b/install.sh
@@ -777,7 +777,31 @@ clean_previous_local_install() {
 install_vice_venv() {
     info "Creating a dedicated virtual environment at $VENV_DIR"
     rm -rf "$VENV_DIR"
-    python3 -m venv --system-site-packages "$VENV_DIR"
+
+    # On Arch-family systems, pacman installs Python modules for the distro
+    # interpreter under /usr/bin. A pyenv/asdf/conda Python earlier in PATH
+    # cannot see python-pyqt6/python-pyqt6-webengine even with
+    # --system-site-packages, which previously made the installer silently
+    # replace the distro WebEngine with PyPI's H.264-less wheel.
+    local python_bin
+    python_bin="$(command -v python3)"
+    if [[ "$PKG" == "pacman" && -x /usr/bin/python3 ]]; then
+        python_bin=/usr/bin/python3
+    fi
+    info "Using Python for Vice venv: $python_bin ($("$python_bin" --version 2>&1))"
+
+    if [[ "$PKG" == "pacman" ]]; then
+        if ! "$python_bin" -c 'import PyQt6.QtWebEngineWidgets, qtpy' >/dev/null 2>&1; then
+            error "Arch Qt packages are installed but are not importable by $python_bin."
+            error "Vice will not replace them with PyPI Qt because that build cannot decode H.264."
+            error "Refresh the Arch/CachyOS package set, then rerun the installer:"
+            error "  sudo pacman -Syu python python-pyqt6 python-pyqt6-webengine python-qtpy"
+            exit 1
+        fi
+        info "System PyQt6 + QtWebEngine are importable; preserving distro H.264 support."
+    fi
+
+    "$python_bin" -m venv --system-site-packages "$VENV_DIR"
     "$VENV_DIR/bin/python" -m pip install --upgrade pip
 
     # Two-step install to avoid shadowing system Python packages:
@@ -812,7 +836,18 @@ OPTIONAL = {
 }
 
 def _missing(deps):
-    return [pypi for mod, pypi in deps.items() if importlib.util.find_spec(mod) is None]
+    missing = []
+    for mod, pypi in deps.items():
+        try:
+            spec = importlib.util.find_spec(mod)
+        except (ImportError, ModuleNotFoundError, AttributeError):
+            # find_spec("parent.child") imports the parent package first.
+            # A completely absent optional parent (for example PyQt6)
+            # is simply a missing dependency, not an installer failure.
+            spec = None
+        if spec is None:
+            missing.append(pypi)
+    return missing
 
 core_missing = _missing(CORE)
 if core_missing:

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -1,6 +1,8 @@
+import importlib
 import re
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -50,6 +52,46 @@ class InstallScriptTests(unittest.TestCase):
         self.assertIn("Silverblue", script)
         self.assertIn("dnf is not the right install path", script)
         self.assertLess(script.index("if is_rpm_ostree_system; then"), script.index("detect_package_manager()"))
+
+    def test_arch_qt_preflight_preserves_existing_install(self) -> None:
+        """A failed Arch Qt preflight must not remove a working install."""
+        install_venv = re.search(
+            r"install_vice_venv\(\) \{\n(?P<body>.*?)\n\}",
+            self.script,
+            flags=re.S,
+        )
+        self.assertIsNotNone(install_venv)
+        body = install_venv.group("body")
+
+        qt_check = body.index("import PyQt6.QtWebEngineWidgets, qtpy")
+        cleanup = body.index("clean_previous_local_install")
+        remove_venv = body.index('rm -rf "$VENV_DIR"')
+        create_venv = body.index('"$python_bin" -m venv')
+
+        self.assertLess(qt_check, cleanup)
+        self.assertLess(cleanup, remove_venv)
+        self.assertLess(remove_venv, create_venv)
+        self.assertEqual(self.script.count('rm -rf "$VENV_DIR"'), 1)
+
+    def test_missing_optional_parent_is_reported_as_missing(self) -> None:
+        """find_spec imports dotted-name parents and may raise if one is absent."""
+        helper = re.search(
+            r"^def _missing\(deps\):\n.*?^    return missing$",
+            self.script,
+            flags=re.M | re.S,
+        )
+        self.assertIsNotNone(helper)
+
+        namespace = {"importlib": importlib}
+        exec(helper.group(0), namespace)
+        dependency = {"PyQt6.QtWebEngineWidgets": "PyQt6-WebEngine>=6.5"}
+        missing_parent = ModuleNotFoundError("No module named 'PyQt6'")
+
+        with mock.patch.object(importlib.util, "find_spec", side_effect=missing_parent):
+            self.assertEqual(
+                namespace["_missing"](dependency),
+                ["PyQt6-WebEngine>=6.5"],
+            )
 
     def test_gsr_build_runs_as_user_with_sudo_only_for_install(self) -> None:
         """Regression test for #84: building under sudo left a root-owned


### PR DESCRIPTION
## Summary

Fixes an Arch-based installer failure where Vice can install the correct PyQt6 packages with pacman, but then fail to see them when creating its virtual environment.

If `python3` in the user's PATH points to something like pyenv, asdf, Conda, or another non-system Python, `--system-site-packages` cannot see the packages pacman installed for `/usr/bin/python3`. Vice then treats PyQt6/QtWebEngine as missing and may fall back to the PyPI WebEngine build.

This changes the installer to:

- Use `/usr/bin/python3` for the Vice venv on pacman systems.
- Verify the pacman-installed PyQt6, QtWebEngine, and QtPy packages are importable before continuing.
- Treat a missing parent package such as `PyQt6` as a missing optional dependency instead of crashing while checking `PyQt6.QtWebEngineWidgets`.

This keeps Arch installs using the distro QtWebEngine package and avoids the PyPI WebEngine fallback, which does not provide the H.264 playback support Vice expects.

Tested on CachyOS/Arch with a reinstall. The existing test suite also passes on Python 3.10, 3.12, and 3.13.

Happy to adjust the approach if you would prefer the installer to handle Python selection differently.